### PR TITLE
fix(proven-needs): remove redundant skill-loading mechanism from invocation instructions

### DIFF
--- a/skills/proven-needs/SKILL.md
+++ b/skills/proven-needs/SKILL.md
@@ -80,9 +80,9 @@ The orchestrator does not produce artifacts directly. It invokes capabilities (t
 
 ### Invoking a capability
 
-To invoke a capability, **load its skill by name** using the skill-loading tool (e.g., load `needs-stories`). Each capability is a separate skill with its own instructions for artifact format, versioning, quality checks, and the observe/evaluate/execute cycle.
+To invoke a capability, **load its skill** (e.g., `needs-stories`). Each capability is a separate skill with its own instructions for artifact format, versioning, quality checks, and the observe/evaluate/execute cycle.
 
-**Do NOT attempt to perform a capability's work without first loading its skill definition.** The orchestrator's job is to plan and coordinate -- the capability skills contain the detailed instructions for producing correct artifacts.
+**Do NOT attempt to perform a capability's work without first loading its skill.** The orchestrator's job is to plan and coordinate -- the capability skills contain the detailed instructions for producing correct artifacts.
 
 Invocation steps:
 1. Load the skill by name (e.g., `needs-stories`, `needs-spec`, `needs-design`)


### PR DESCRIPTION
## Summary

- Removes the vague "using the skill-loading tool" phrase from the orchestrator's capability invocation instructions — agents already know how to load skills from their own toolbox, so describing the mechanism was redundant and risked confusion
- Drops "by name" and "definition" from the same section as unnecessary qualifiers

Closes #30