### PR TITLE
refactor: optimize workflow instructions for conciseness and reduce d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,19 @@ flowchart TD
     style LOG fill:#2196F3,color:#fff,stroke:none
 ```
 
-1. **Observe** current state (artifacts, codebase, dependencies, security posture)
-2. **Declare** desired state ("Users can reset password via SMS", "No vulnerable dependencies")
-3. **Evaluate** feasibility against constraints
-4. **Derive** the minimal transition plan (which capabilities to invoke)
-5. **Execute** the transition
-6. **Validate** the desired state is now true
-
 The system figures out what needs to happen. You declare what must be true.
 
-### Capability Invocation
+## Entry Point
 
-During the **Execute** phase, the orchestrator invokes capabilities in dependency order. The pipeline is not rigid -- the orchestrator derives what is needed dynamically and can skip steps whose artifacts are already current.
+Load the `proven-needs` skill. It is the single orchestrator that accepts intents, classifies them, and invokes the appropriate capabilities.
+
+```
+I want users to be able to browse products, add them to cart, and checkout
+```
+
+The orchestrator will: decompose into features, confirm grouping, then for each feature create stories, derive specs, design, plan tasks, generate tests, implement -- resolving divergences and recording ADRs along the way.
+
+## Capabilities
 
 ```mermaid
 flowchart LR
@@ -99,255 +100,26 @@ flowchart LR
     style CONSTRAINTS fill:#FF9800,color:#fff,stroke:none
 ```
 
-**Key relationships:**
-- **Solid arrows** = primary dependency (required upstream artifact)
-- **Dotted arrows** = optional or fallback paths
-- `needs-spec` is always generated -- every feature gets a specification
-- `needs-design` requires both stories and spec
-- `needs-tasks` prefers design but can derive tasks directly from stories
-- `needs-implementation` prefers tasks but can work story-by-story from design alone
-- `needs-tests` derives test cases from specs *before* implementation -- tests are the acceptance gate for `needs-implementation`
-- `needs-design` can trigger `needs-adr` creation for technology decisions (lateral invocation)
-- `needs-security` delegates dependency vulnerability fixes to `needs-dependencies`
-- After implementation, divergences between design and code are reported to the orchestrator. The user decides per-divergence whether to update the design or fix the code.
+**Solid arrows** = required dependency. **Dotted** = optional/fallback.
 
-Independent features can be processed concurrently.
+| Scope | Capability | Skill | Domain |
+|---|---|---|---|
+| Feature | Stories | `needs-stories` | WHY: user needs |
+| Feature | Specs | `needs-spec` | WHAT: black-box requirements |
+| Feature | Design | `needs-design` | HOW: implementation blueprint |
+| Feature | Tasks | `needs-tasks` | WORK: phased coding units |
+| Feature | Tests | `needs-tests` | VERIFY: spec-derived test cases |
+| Feature | Implementation | `needs-implementation` | CODE: working software |
+| Project | ADRs | `needs-adr` | Technology decisions |
+| Project | Architecture | `needs-architecture` | System structure (C4 model) |
+| Project | Dependencies | `needs-dependencies` | Dependency management |
+| Project | Security | `needs-security` | Security posture |
+| Project | Compliance | `needs-compliance` | License/policy compliance |
+| Support | EARS | `ears-requirements` | Requirement syntax reference |
 
-### Artifact Traceability
+Every capability follows **observe/evaluate/execute**: assess current state, check if action is needed and constraints allow it, make minimum changes.
 
-Each capability reads upstream artifacts and writes its own. The two diagrams below separate ownership (writes) from dependencies (reads) for clarity.
-
-#### Artifact Ownership (writes)
-
-Each capability owns and produces specific artifacts. `state-log.adoc` is managed by the orchestrator.
-
-```mermaid
-flowchart LR
-    subgraph feature ["Feature Pipeline"]
-        NS["needs-stories"] --> STORIES[("user-stories.adoc")]
-        NSP["needs-spec"] --> SPEC[("spec.adoc")]
-        NADR["needs-adr"] --> ADRS[("docs/adrs/")]
-        ND["needs-design"] --> DESIGN[("design.adoc<br/>data-model.adoc<br/>contracts/")]
-        NT["needs-tasks"] --> TASKS[("tasks.adoc")]
-        NI["needs-implementation"] --> CODE[("source code")]
-        NTS["needs-tests"] --> TESTFILES[("test files")]
-    end
-
-    subgraph project ["Project-wide"]
-        NARCH["needs-architecture"] --> ARCH[("architecture.adoc")]
-        NDEPS["needs-dependencies"] --> DEPS[("package manifests<br/>lockfiles")]
-        NSEC["needs-security"] --> CODE2[("source code")]
-        NCOMP["needs-compliance"] --> DEPS2[("package manifests")]
-    end
-
-    style feature fill:transparent,stroke:#555,stroke-width:1px
-    style project fill:transparent,stroke:#555,stroke-width:1px
-```
-
-#### Artifact Dependencies (reads)
-
-Solid lines are primary inputs; dashed lines are fallback or optional inputs. All capabilities also read `docs/constraints.adoc` during their Evaluate phase (omitted for clarity).
-
-```mermaid
-flowchart RL
-    subgraph artifacts ["Artifacts"]
-        STORIES[("user-stories.adoc")]
-        SPEC[("spec.adoc")]
-        ADRS[("docs/adrs/")]
-        DESIGN[("design.adoc<br/>data-model.adoc<br/>contracts/")]
-        TASKS[("tasks.adoc")]
-        CODE[("source code")]
-        DEPS[("package manifests<br/>lockfiles")]
-    end
-
-    subgraph feature ["Feature Pipeline"]
-        NSP["needs-spec"]
-        ND["needs-design"]
-        NT["needs-tasks"]
-        NI["needs-implementation"]
-        NTS["needs-tests"]
-    end
-
-    subgraph project ["Project-wide"]
-        NARCH["needs-architecture"]
-        NDEPS["needs-dependencies"]
-        NSEC["needs-security"]
-        NCOMP["needs-compliance"]
-    end
-
-    %% ── Feature reads (solid = primary) ───────────────────────
-    STORIES -->|reads| NSP
-    STORIES -->|reads| ND
-    SPEC -->|reads| ND
-    SPEC -->|reads| NTS
-    DESIGN -->|reads| NT
-    TASKS -->|reads| NI
-
-    %% ── Feature reads (dashed = fallback / optional) ──────────
-    STORIES -.->|fallback| NT
-    DESIGN -.->|fallback| NI
-    DESIGN -.->|reads| NTS
-    ADRS -.->|reads| ND
-
-    %% ── Project-wide reads ────────────────────────────────────
-    DESIGN -.->|reads| NARCH
-    ADRS -.->|reads| NARCH
-    CODE -.->|reads| NARCH
-    DEPS -->|reads| NDEPS
-    CODE -->|reads| NSEC
-    DEPS -.->|reads| NSEC
-    DEPS -->|reads| NCOMP
-
-    style artifacts fill:transparent,stroke:#555,stroke-width:1px
-    style feature fill:transparent,stroke:#555,stroke-width:1px
-    style project fill:transparent,stroke:#555,stroke-width:1px
-```
-
-| Capability | Reads | Writes |
-|---|---|---|
-| `needs-stories` | `constraints.adoc` | `user-stories.adoc` |
-| `needs-spec` | `user-stories.adoc`, `constraints.adoc` | `spec.adoc` |
-| `needs-design` | `user-stories.adoc`, `spec.adoc`, ADRs, `constraints.adoc`, `architecture.adoc` | `design.adoc`, `data-model.adoc`, `contracts/` |
-| `needs-tasks` | `design.adoc` (or `user-stories.adoc` as fallback), `spec.adoc`, `constraints.adoc` | `tasks.adoc` |
-| `needs-implementation` | `tasks.adoc` (or `design.adoc` as fallback), `user-stories.adoc`, `spec.adoc`, `constraints.adoc`, ADRs | source code |
-| `needs-tests` | `spec.adoc`, `design.adoc`, `user-stories.adoc`, `constraints.adoc` | test files |
-| `needs-stories` | `docs/constraints.adoc` | `user-stories.adoc` |
-| `needs-spec` | `user-stories.adoc`, `docs/constraints.adoc` | `spec.adoc` |
-| `needs-design` | `user-stories.adoc`, `spec.adoc`, ADRs, `docs/constraints.adoc`, `architecture.adoc` | `design.adoc`, `data-model.adoc`, `contracts/` |
-| `needs-tasks` | `design.adoc` (or `user-stories.adoc` as fallback), `spec.adoc`, `docs/constraints.adoc` | `tasks.adoc` |
-| `needs-implementation` | `tasks.adoc` (or `design.adoc` as fallback), `user-stories.adoc`, `spec.adoc`, `docs/constraints.adoc`, ADRs | source code |
-| `needs-tests` | `spec.adoc`, `design.adoc`, `user-stories.adoc`, `docs/constraints.adoc`, source code | test files |
-| `needs-adr` | existing ADRs | `docs/adrs/*.adoc`, `index.adoc` |
-| `needs-architecture` | all feature designs, ADRs, `docs/constraints.adoc`, codebase | `docs/architecture.adoc` |
-| `needs-dependencies` | package manifests, `docs/constraints.adoc` | package manifests, lockfiles |
-| `needs-security` | codebase, dependencies, config, `docs/constraints.adoc` | source code, config |
-| `needs-compliance` | dependencies, `docs/constraints.adoc` | dependencies, `docs/constraints.adoc` |
-
-## Entry Point
-
-Load the `proven-needs` skill. It is the single orchestrator that accepts intents, classifies them, and invokes the appropriate capabilities.
-
-```
-I want users to be able to browse products, add them to cart, and checkout
-```
-
-The orchestrator will:
-1. Decompose this into feature packages (product-browsing, shopping-cart, checkout)
-2. Ask you to confirm the grouping
-3. For each feature: create stories, derive specs, design, plan tasks, generate tests, implement
-4. Resolve any design divergences (user decides: update design or fix code)
-5. Record technology decisions as ADRs along the way
-6. Update the architecture document when all features are implemented
-
-## Core Concepts
-
-### Desired State
-A declarative statement of what must be true. Not a task list -- an intent.
-
-- "Users can reset their password via SMS" (feature)
-- "No dependencies have known vulnerabilities" (maintenance)
-- "All API endpoints enforce rate limiting" (constraint)
-
-### Constraints
-Project-wide invariants that must not be violated. Defined in `docs/constraints.adoc`:
-
-- License compliance rules
-- Security policies
-- Architecture boundaries
-- Quality standards
-- Performance SLAs
-
-Cross-cutting requirements belong here, not in feature specs.
-
-### Feature Packages
-Self-contained units of work at `docs/features/<slug>/`:
-
-```
-docs/features/shopping-cart/
-├── user-stories.adoc    # WHY: user needs
-├── spec.adoc            # WHAT: testable requirements
-├── design.adoc          # HOW: implementation blueprint
-└── tasks.adoc           # WORK: phased task breakdown
-```
-
-Each feature is fully independent -- it can be specified, designed, and implemented without reading other features.
-
-Features can be **archived** when superseded or no longer relevant. Archived features remain on disk as historical records but are skipped during intent classification.
-
-### State Log
-Append-only audit trail at `docs/state-log.adoc` recording every transition: what was intended, what changed, what was verified.
-
-## Capabilities
-
-### Feature-Scoped (operate within a feature package)
-
-| Capability | Skill | What it does |
-|---|---|---|
-| Stories | `needs-stories` | Create user stories explaining WHY |
-| Specifications | `needs-spec` | Derive black-box testable requirements (WHAT) |
-| Design | `needs-design` | Create implementation blueprint (HOW) |
-| Tasks | `needs-tasks` | Break design into phased coding units |
-| Tests | `needs-tests` | Derive and generate tests from specifications (VERIFY) |
-| Implementation | `needs-implementation` | Write and verify code |
-
-### Project-Wide (operate at the project level)
-
-| Capability | Skill | What it does |
-|---|---|---|
-| ADRs | `needs-adr` | Record technology decisions |
-| Architecture | `needs-architecture` | Document current system architecture |
-| Dependencies | `needs-dependencies` | Manage and update dependency graph |
-| Security | `needs-security` | Assess and remediate security posture |
-| Compliance | `needs-compliance` | Verify license and policy compliance |
-
-### Supporting
-
-| Skill | What it does |
-|---|---|
-| `ears-requirements` | EARS methodology reference for stories and specs |
-
-Every capability follows the **observe/evaluate/execute** pattern:
-
-```mermaid
-flowchart TD
-    O["Observe<br/><i>Read artifacts, codebase,<br/>constraints in this domain</i>"]
-    E["Evaluate<br/><i>Does desired state require action?<br/>Do constraints allow it?</i>"]
-    X["Execute<br/><i>Make the minimum changes.<br/>Create or update artifacts.</i>"]
-
-    O --> E
-    E -->|Action needed| X
-    E -->|"Already current"| DONE["Report: no action needed"]
-    E -->|"Constraint violation"| BLOCK["Report violation<br/>to orchestrator"]
-    X --> VERIFY["Verify output"]
-    VERIFY --> REPORT["Return result<br/>to orchestrator"]
-
-    style DONE fill:#4CAF50,color:#fff,stroke:none
-    style BLOCK fill:#f44336,color:#fff,stroke:none
-    style REPORT fill:#2196F3,color:#fff,stroke:none
-```
-
-1. **Observe** -- assess current state in this domain
-2. **Evaluate** -- does the desired state require action? do constraints allow it?
-3. **Execute** -- make the minimum changes
-
-## Artifact Lifecycle
-
-| Artifact | Location | Lifecycle |
-|---|---|---|
-| Constraints | `docs/constraints.adoc` | Stable, changes rarely |
-| User Stories | `docs/features/<slug>/user-stories.adoc` | Living, versioned per feature |
-| Specifications | `docs/features/<slug>/spec.adoc` | Living, synced with stories |
-| Design | `docs/features/<slug>/design.adoc` | Living, synced with stories and specs |
-| Tasks | `docs/features/<slug>/tasks.adoc` | Ephemeral -- disposable once tests verify implementation |
-| Tests | `tests/features/<slug>/` | Living, synced with specs |
-| ADRs | `docs/adrs/NNNN-title.adoc` | Permanent, append-only |
-| Architecture | `docs/architecture.adoc` | Living, reflects current system |
-| State Log | `docs/state-log.adoc` | Append-only audit trail |
-| Code | project source | Living -- the actual system |
-
-### Version Tracking and Staleness
-
-Each downstream artifact tracks its upstream version. When an upstream artifact changes, downstream artifacts become stale and need syncing.
+## Artifact Traceability
 
 ```mermaid
 flowchart LR
@@ -369,63 +141,132 @@ flowchart LR
     style T fill:#9C27B0,color:#fff,stroke:none
 ```
 
-When stories change, specs become stale. When specs change, the design becomes stale. When the design changes, tasks become stale. The orchestrator detects these cascades during the Evaluate phase and includes sync steps in the transition plan.
+Each downstream artifact tracks its upstream version. When an upstream changes, downstream artifacts become stale. The orchestrator detects cascades and includes sync steps in the transition plan.
 
-## Risk Classification
-
-Transitions are auto-approved or require confirmation based on risk:
-
-| Risk | Auto-approve? | Examples |
+| Capability | Reads | Writes |
 |---|---|---|
-| **Low** | Yes | Patch dependency updates, metadata fixes |
-| **Medium** | Propose, ask | Minor dependency updates, spec syncs |
-| **High** | Full plan, require approval | New features, architecture changes, code changes |
+| `needs-stories` | `docs/constraints.adoc` | `user-stories.adoc` |
+| `needs-spec` | `user-stories.adoc`, `docs/constraints.adoc` | `spec.adoc` |
+| `needs-design` | `user-stories.adoc`, `spec.adoc`, ADRs, `docs/constraints.adoc`, `architecture.adoc` | `design.adoc`, `data-model.adoc`, `contracts/` |
+| `needs-tasks` | `design.adoc` (or `user-stories.adoc` fallback), `spec.adoc`, `docs/constraints.adoc` | `tasks.adoc` |
+| `needs-implementation` | `tasks.adoc` (or `design.adoc` fallback), `user-stories.adoc`, `spec.adoc`, `docs/constraints.adoc`, ADRs | source code |
+| `needs-tests` | `spec.adoc`, `design.adoc`, `user-stories.adoc`, `docs/constraints.adoc`, source code | test files |
+| `needs-adr` | existing ADRs | `docs/adrs/*.adoc`, `index.adoc` |
+| `needs-architecture` | all feature designs, ADRs, `docs/constraints.adoc`, codebase | `docs/architecture.adoc` |
+| `needs-dependencies` | package manifests, `docs/constraints.adoc` | package manifests, lockfiles |
+| `needs-security` | codebase, dependencies, config, `docs/constraints.adoc` | source code, config |
+| `needs-compliance` | dependencies, `docs/constraints.adoc` | dependencies, `docs/constraints.adoc` |
 
-## EARS Requirements
+## Visual Reference
 
-Acceptance criteria and specifications use [EARS sentence types](skills/ears-requirements/references/ears-reference.adoc):
+### Intent Classification
 
-| Type | Pattern | Use for |
-|------|---------|---------|
-| Ubiquitous | The \<system\> shall \<response\>. | Always-on behavior |
-| Event-driven | When \<trigger\>, the \<system\> shall \<response\>. | User actions or events |
-| State-driven | While \<state\>, the \<system\> shall \<response\>. | Behavior during a state |
-| Unwanted behavior | If \<trigger\>, then the \<system\> shall \<response\>. | Errors and edge cases |
-| Optional | Where \<feature\>, the \<system\> shall \<response\>. | Feature-dependent behavior |
+```mermaid
+flowchart TD
+    INPUT["User intent"] --> SIGNALS{"Analyze signals"}
 
-## Example
-
-Given the intent: "I want an e-commerce site where users can browse products, add them to cart, and checkout"
-
-The orchestrator produces:
-
+    SIGNALS -->|"User journey"| FEAT["Feature evolution"]
+    SIGNALS -->|"Universal quantifiers"| CONST["Constraint declaration"]
+    SIGNALS -->|"Sync/update language"| ART["Artifact maintenance"]
+    SIGNALS -->|"Packages, vulns"| DEP["Dependency maintenance"]
+    SIGNALS -->|"System structure"| ARCH["Architecture evolution"]
+    SIGNALS -->|"Tests, coverage"| QUAL["Quality improvement"]
+    SIGNALS -->|"Docs, architecture"| DOC["Documentation"]
 ```
-docs/features/
-├── product-browsing/
-│   ├── user-stories.adoc   # 2 stories: View Catalog, Search
-│   ├── spec.adoc            # PROD-001 through PROD-008
-│   ├── design.adoc          # Frontend + API design
-│   └── tasks.adoc           # 3 phases, 8 tasks
-├── shopping-cart/
-│   ├── user-stories.adoc   # 2 stories: Add to Cart, View Cart
-│   ├── spec.adoc            # CART-001 through CART-008
-│   ├── design.adoc          # CartService + UI design
-│   └── tasks.adoc           # 3 phases, 9 tasks
-└── checkout/
-    ├── user-stories.adoc   # 1 story: Checkout Process
-    ├── spec.adoc            # CHK-001 through CHK-006
-    ├── design.adoc          # Payment flow design
-    └── tasks.adoc           # 3 phases, 7 tasks
 
-docs/adrs/
-├── index.adoc
-├── 0001-use-typescript.adoc
-├── 0002-use-postgresql.adoc
-└── 0003-use-stripe.adoc
+### Constraint Detection
 
-docs/architecture.adoc
-docs/constraints.adoc
-docs/state-log.adoc
+```mermaid
+flowchart TD
+    INTENT["Intent"] --> Q1{"Universal scope?"}
+    Q1 -->|Yes| Q2{"System-as-subject?"}
+    Q1 -->|No| FEATURE["Feature requirement"]
+    Q2 -->|Yes| Q3{"No user journey?"}
+    Q2 -->|No| FEATURE
+    Q3 -->|Yes| Q4{"Future-proof?"}
+    Q3 -->|No| ASK["Ask user"]
+    Q4 -->|Yes| CONSTRAINT["Constraint"]
+    Q4 -->|No| ASK
+```
+
+### Feature Decomposition (Two-Pass)
+
+```mermaid
+flowchart TD
+    START((Intent)) --> CHECK{Existing features?}
+    CHECK -->|No: Greenfield| GF_P1
+    CHECK -->|Yes: Evolution| EV_P1
+
+    subgraph greenfield ["Greenfield"]
+        GF_P1["Pass 1: Draft stories into _drafts/"]
+        GF_P1 --> GF_COHESION["Analyze cohesion"] --> GF_PROPOSE["Propose groupings"]
+        GF_PROPOSE --> GF_CONFIRM{Confirm?}
+        GF_CONFIRM -->|Yes| GF_P2["Pass 2: Distribute to packages"]
+        GF_CONFIRM -->|Adjust| GF_PROPOSE
+    end
+
+    subgraph evolution ["Evolution"]
+        EV_P1["Pass 1: Draft + classify against existing"]
+        EV_P1 --> EV_PROPOSE["Present mapping"]
+        EV_PROPOSE --> EV_CONFIRM{Confirm?}
+        EV_CONFIRM -->|Yes| EV_P2["Pass 2: Distribute"]
+        EV_CONFIRM -->|Adjust| EV_PROPOSE
+    end
+
+    GF_P2 --> DONE((Ready))
+    EV_P2 --> DONE
+```
+
+### Risk Classification
+
+```mermaid
+flowchart TD
+    CHANGE["Transition"] --> FACTORS["Assess: scope, constraints, reversibility, code impact"]
+    FACTORS --> LOW["Low risk → auto-approve"]
+    FACTORS --> MED["Medium → propose, ask"]
+    FACTORS --> HIGH["High → full plan, require approval"]
+```
+
+### Design Divergence Resolution
+
+```mermaid
+sequenceDiagram
+    participant Impl as needs-implementation
+    participant Orch as Orchestrator
+    participant User as User
+    participant Design as needs-design
+
+    Impl->>Orch: Report divergences
+    Orch->>User: Present with analysis
+
+    loop Each divergence
+        User->>Orch: Choose resolution
+        alt Update design
+            Orch->>Design: Reconciliation mode
+        else Fix code
+            Orch->>Impl: Fix divergence
+        end
+    end
+```
+
+### Feature Status
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stories : user-stories.adoc
+    Stories --> Specified : spec.adoc
+    Specified --> Designed : design.adoc (Current)
+    Designed --> Planned : tasks.adoc (Current)
+    Planned --> Tested : tests from spec
+    Tested --> Implemented : all tests pass
+
+    Stories --> Archived
+    Specified --> Archived
+    Designed --> Archived
+    Planned --> Archived
+    Tested --> Archived
+    Implemented --> Archived
+    Archived --> Stories : un-archived
 ```
 
 ## What This Is Not

--- a/skills/needs-adr/SKILL.md
+++ b/skills/needs-adr/SKILL.md
@@ -1,61 +1,21 @@
 ---
 name: needs-adr
-description: Create and manage Architecture Decision Records (ADRs). Use when the proven-needs orchestrator identifies technology decisions that need recording, or when explicitly asked to record a decision. Operates at the project level in docs/adrs/. ADRs are permanent, append-only records referenced by feature designs across all feature packages.
+description: Create and manage Architecture Decision Records (ADRs). Use when the proven-needs orchestrator identifies technology decisions that need recording, or when explicitly asked to record a decision. Operates at the project level in docs/adrs/. ADRs are permanent, append-only records referenced by feature designs.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator or by the `needs-design` capability when technology decisions are identified during the design process.
+Invoked by the `proven-needs` orchestrator or by `needs-design` when technology decisions are identified during the design process.
 
 ## Observe
 
-Assess the current state of architecture decisions.
-
-### 1. Read existing ADRs
-
-Look for `docs/adrs/` and `docs/adrs/index.adoc`.
-
-**If the directory exists:** Read `index.adoc` to understand existing decisions. Extract:
-- All ADR numbers, titles, statuses, and dates
-- The next available sequence number
-
-**If no directory exists:** Note that no ADRs exist. Next number is `0001`.
-
-### 2. Read constraints
-
-Read `docs/constraints.adoc`. Identify constraints that may be relevant to the decision (architecture constraints, licensing constraints for technology choices).
-
-### 3. Report observation
-
-Return to the orchestrator:
-```
-ADRs: {exists: true/false, count: N, accepted: N, deprecated: N, superseded: N, next-number: "NNNN"}
-```
+1. Check for `docs/adrs/` and `docs/adrs/index.adoc`. If exists, read all ADR numbers, titles, statuses, dates, and next available sequence number. If not, next number is `0001`.
+2. Read `docs/constraints.adoc` for relevant constraints (architecture, licensing).
 
 ## Evaluate
 
-Given the desired state (a technology decision that needs recording), determine what action is needed.
-
-### 1. Is this decision already recorded?
-
-- Search existing ADRs for decisions covering the same topic
-- If an accepted ADR already covers this decision → no action needed (report to orchestrator)
-- If an accepted ADR exists but the decision has changed → supersession needed
-- If no ADR covers this topic → new ADR needed
-
-### 2. Check constraints
-
-- Would the proposed technology decision violate any constraint? (e.g., licensing constraint for a dependency choice)
-- Flag constraint conflicts to the orchestrator
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / supersede / none
-Existing related ADR: ADR-NNNN (if applicable)
-Constraint conflicts: [list or none]
-```
+1. Search existing ADRs for the same topic. Already covered → no action. Decision changed → supersession needed. Not covered → new ADR needed.
+2. Check if proposed technology violates any constraint. Flag conflicts.
 
 ## Execute
 
@@ -63,14 +23,10 @@ Constraint conflicts: [list or none]
 
 #### 1. Gather decision context
 
-For each decision, identify:
-- **Context** -- what is the issue motivating this decision?
-- **Decision** -- what is the chosen approach?
-- **Consequences** -- what becomes easier or harder?
-- **Alternatives considered** -- what other options were evaluated and why rejected?
+Identify: Context (what issue?), Decision (what approach?), Consequences (what trade-offs?), Alternatives (what else considered?).
 
-**When invoked by the orchestrator standalone:** Ask the user for this information.
-**When invoked from `needs-design`:** The design capability provides the context and asks the user to confirm.
+- When invoked standalone: ask the user
+- When invoked from `needs-design`: design capability provides context, user confirms
 
 #### 2. Write the ADR file
 
@@ -83,52 +39,23 @@ Create `docs/adrs/NNNN-<kebab-case-title>.adoc`:
 :deciders: <who was involved>
 
 == Context
-
-<What is the issue motivating this decision?>
+<What motivates this decision?>
 
 == Decision
-
-<What is the change that is being made?>
+<What change is being made?>
 
 == Consequences
-
-<What becomes easier or harder because of this change?>
+<What becomes easier or harder?>
 
 == Alternatives Considered
 
 === <Alternative 1>
 <Description and reason for rejection>
-
-=== <Alternative 2>
-<Description and reason for rejection>
 ```
 
-**Status values:**
-- `Proposed` -- decision not yet confirmed
-- `Accepted` -- decision is in effect
-- `Deprecated` -- decision is no longer relevant
-- `Superseded by ADR-NNNN` -- replaced by a newer decision
+**Status values:** `Proposed` (unconfirmed), `Accepted` (in effect), `Deprecated` (no longer relevant), `Superseded by ADR-NNNN` (replaced).
 
-```mermaid
-stateDiagram-v2
-    [*] --> Proposed : ADR created
-    Proposed --> Accepted : decision confirmed
-    Accepted --> Deprecated : no longer relevant
-    Accepted --> Superseded : replaced by new ADR
-
-    Deprecated --> [*]
-    Superseded --> [*]
-
-    note right of Superseded
-        New ADR references the old one.
-        Old ADR status set to
-        "Superseded by ADR-NNNN".
-    end note
-```
-
-**Numbering:** Always use 4-digit zero-padded sequence numbers (`0001`, `0002`, ...).
-
-**File naming:** `NNNN-kebab-case-title.adoc` (e.g., `0001-use-typescript.adoc`).
+**Numbering:** 4-digit zero-padded (`0001`, `0002`, ...). File naming: `NNNN-kebab-case-title.adoc`.
 
 #### 3. Update the index
 
@@ -143,41 +70,25 @@ Create or update `docs/adrs/index.adoc`:
 [cols="1,3,1,1", options="header"]
 |===
 | ADR | Decision | Status | Date
-
-| <<0001-use-typescript.adoc#,ADR-0001>>
-| Use TypeScript for backend
-| Accepted
-| 2026-02-20
-
-| <<0002-use-postgresql.adoc#,ADR-0002>>
-| Use PostgreSQL for persistence
-| Accepted
-| 2026-02-20
+| <<0001-use-typescript.adoc#,ADR-0001>> | Use TypeScript for backend | Accepted | 2026-02-20
 |===
 ```
 
-**Index version rules:**
-- `:version:` uses SemVer, starts at `1.0.0`
-- MINOR bump when ADRs are added
-- PATCH bump for metadata-only changes (status updates, date corrections)
-- MAJOR bumps do not apply since ADRs are never removed
-- Always update `:last-updated:` to today's date
+Index version: MINOR when ADRs added, PATCH for status updates.
 
 ### Superseding an existing ADR
 
-When a decision changes:
-1. Set the old ADR status to `Superseded by ADR-NNNN`
-2. Create a new ADR referencing the old one in its Context section
-3. Update the index
+1. Set old ADR status to `Superseded by ADR-NNNN`
+2. Create new ADR referencing the old one in Context
+3. Update index
 
 ### Deprecating an ADR
 
-When a decision becomes irrelevant:
-1. Set the ADR status to `Deprecated`
-2. Update the index
+1. Set status to `Deprecated`
+2. Update index
 
-Never delete ADR files. ADRs are append-only records.
+Never delete ADR files. ADRs are append-only.
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing an ADR index and two ADR files.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-architecture/SKILL.md
+++ b/skills/needs-architecture/SKILL.md
@@ -1,87 +1,34 @@
 ---
 name: needs-architecture
-description: Create and maintain the system architecture document. Use when the proven-needs orchestrator determines the architecture document needs creating or updating. Operates at the project level, producing docs/architecture.adoc as a living document reflecting the current system state. Supports greenfield projects (from feature designs), existing projects (from codebase analysis), and updates after feature implementations.
+description: Create and maintain the system architecture document. Use when the proven-needs orchestrator determines the architecture document needs creating or updating. Operates at the project level, producing docs/architecture.adoc using the C4 model. Supports greenfield, reverse-engineering, and update modes.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the current state context.
+Invoked by the `proven-needs` orchestrator with current state context.
 
 ## Observe
 
-Assess the current state of architecture documentation.
-
-### 1. Check for existing architecture document
-
-If `docs/architecture.adoc` exists:
-- Read `:version:`, `:last-updated:`
-- Read the Feature Design Sources section to determine which feature design versions the architecture was synthesized from
-- Read the full content
-
-### 2. Check for feature designs
-
-List all feature packages in `docs/features/`. For each, check if `design.adoc` exists and read its `:version:` and `:status:`.
-
-### 3. Read project-wide artifacts
-
-- **`docs/adrs/`** -- read all ADRs with status `Accepted`
-- **`docs/constraints.adoc`** -- read architecture constraints
-
-### 4. Analyze codebase
-
-Check for source files beyond documentation and configuration. Understand:
-- Directory structure, module organization
-- Configuration files (package.json, Cargo.toml, go.mod, etc.)
-- Entry points, key patterns
-
-### 5. Report observation
-
-Return to the orchestrator:
-```
-Architecture: {exists: true/false, version: "X.Y.Z", source-design-version: "X.Y.Z"}
-Feature designs: [{slug: "...", version: "X.Y.Z", status: "..."}]
-Codebase: {exists: true/false, language: "...", framework: "..."}
-ADRs: {count: N, accepted: N}
-Mode: greenfield / reverse-engineer / update
-```
+1. If `docs/architecture.adoc` exists: read `:version:`, `:last-updated:`, Feature Design Sources table, full content.
+2. List all feature packages, check for `design.adoc` with `:version:` and `:status:`.
+3. Read `docs/adrs/` (accepted) and `docs/constraints.adoc` (architecture constraints).
+4. Analyze codebase: directory structure, config files, entry points, patterns.
 
 ## Evaluate
-
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Determine mode
 
 | Existing architecture? | Codebase exists? | Mode |
 |---|---|---|
 | No | No | **Greenfield** -- generate from feature designs |
-| No | Yes | **Reverse-engineer** -- analyze codebase, use designs if available |
-| Yes | Any | **Update** -- refresh the existing architecture document |
+| No | Yes | **Reverse-engineer** -- analyze codebase + designs |
+| Yes | Any | **Update** -- refresh existing document |
 
-### 2. Check preconditions
-
-**Greenfield mode:** At least one feature design must exist. If not, report to orchestrator that designs are needed first.
-
-**Update mode:** Compare each feature's current design version against the version recorded in the architecture document's Feature Design Sources section. If any designs have been updated or new features implemented since the last architecture update, note what has changed.
-
-### 3. Check constraints
-
-Verify that the architecture description will address all architecture constraints from `docs/constraints.adoc`.
-
-### 4. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / update / none
-Mode: greenfield / reverse-engineer / update
-Changes since last update: [list of feature designs that changed]
-Constraint issues: [list or none]
-```
+**Greenfield:** at least one feature design must exist. **Update:** compare feature design versions against Feature Design Sources table to identify changes.
 
 ## Execute
 
 ### Generate or update the architecture document
 
-Write `docs/architecture.adoc` using the C4 model for structural diagrams. The document combines C4 diagrams (via Mermaid) with prose sections for context that diagrams alone cannot convey.
+Write `docs/architecture.adoc` using C4 model diagrams via Mermaid:
 
 ```asciidoc
 = System Architecture
@@ -90,172 +37,78 @@ Write `docs/architecture.adoc` using the C4 model for structural diagrams. The d
 :toc:
 
 == Feature Design Sources
-
 [cols="1,1", options="header"]
 |===
 | Feature | Design Version
-
 | product-browsing | 1.0.0
-| shopping-cart | 1.0.0
-| checkout | 1.0.0
 |===
 
 == Overview
-
-<High-level description of the system, its purpose, and boundaries.>
+<System purpose and boundaries.>
 
 == System Context (C4 Level 1)
-
-<Who uses the system and what external systems does it interact with.>
-
+<Users and external systems.>
 [source,mermaid]
 ----
 C4Context
-  title System Context Diagram
-
-  Person(user, "User", "Description of the user role")
-  System(system, "System Name", "Brief description of the system")
-  System_Ext(ext, "External System", "Brief description")
-
-  Rel(user, system, "Uses")
-  Rel(system, ext, "Integrates with")
+  ...
 ----
 
 == Container View (C4 Level 2)
-
-<Major runtime containers: applications, databases, message queues, file stores.
- Show how containers communicate.>
-
+<Runtime containers and communication.>
 [source,mermaid]
 ----
 C4Container
-  title Container Diagram
-
-  Person(user, "User", "Description")
-
-  System_Boundary(system, "System Name") {
-    Container(app, "Application", "Technology", "Description")
-    ContainerDb(db, "Database", "Technology", "Description")
-  }
-
-  System_Ext(ext, "External System", "Description")
-
-  Rel(user, app, "Uses", "HTTPS")
-  Rel(app, db, "Reads/writes", "SQL")
-  Rel(app, ext, "Calls", "HTTPS/JSON")
+  ...
 ----
 
 == Component View (C4 Level 3)
-
-<Internal structure of containers with significant complexity.
- Show major modules, services, or layers within a container.
- Include this section only when a container has meaningful internal structure.>
-
-[source,mermaid]
-----
-C4Component
-  title Component Diagram - <Container Name>
-
-  Container_Boundary(container, "Container Name") {
-    Component(comp1, "Component", "Technology", "Description")
-    Component(comp2, "Component", "Technology", "Description")
-  }
-
-  ContainerDb(db, "Database", "Technology", "Description")
-
-  Rel(comp1, comp2, "Uses")
-  Rel(comp2, db, "Reads/writes")
-----
+<Internal structure of complex containers. Include only when meaningful.>
 
 == Deployment View (C4 Level 4)
-
-<How containers are deployed to infrastructure.
- Include only for non-trivial deployment topologies.>
-
-[source,mermaid]
-----
-C4Deployment
-  title Deployment Diagram
-
-  Deployment_Node(cloud, "Cloud Provider", "Description") {
-    Deployment_Node(runtime, "Runtime", "Description") {
-      Container(app, "Application", "Technology", "Description")
-    }
-    Deployment_Node(data, "Data Tier", "Description") {
-      ContainerDb(db, "Database", "Technology", "Description")
-    }
-  }
-----
+<Infrastructure topology. Include only for non-trivial deployments.>
 
 == Technology Stack
-
-<Languages, frameworks, databases, infrastructure.
- Reference relevant ADRs for rationale.>
-
-* <<adrs/0001-use-typescript.adoc#,ADR-0001>>: TypeScript (backend and frontend)
-* <<adrs/0002-use-postgresql.adoc#,ADR-0002>>: PostgreSQL (persistence)
+<Languages, frameworks, DBs. Reference ADRs for rationale.>
 
 == Data Architecture
-
-<Data stores, schemas, data flow between components.>
+<Data stores, schemas, flow.>
 
 == Cross-Cutting Concerns
-
-<Authentication, logging, error handling, monitoring, etc.
- Skip sections that do not apply.>
+<Auth, logging, errors, monitoring. Skip sections that don't apply.>
 ```
 
 ### C4 level inclusion
 
-The C4 levels included in the architecture document are adaptive based on project complexity. The orchestrator determines the appropriate levels during invocation.
+Adaptive based on project complexity:
 
-| Project Type | C4 Levels | Rationale |
-|---|---|---|
-| Libraries, SDKs | L1 + L2 only | No deployment; containers are the library and its consumers |
-| CLI tools | L1 + L2 only | Simple runtime; L2 shows the CLI and its data stores |
-| Web applications (monolith) | L1 + L2 + L3 (backend) | Backend container benefits from component breakdown |
-| Web applications (frontend + API) | L1 + L2 + L3 (API) | API container has meaningful internal structure |
-| Microservices / distributed | L1 + L2 + L3 + L4 | Multiple containers with complex deployment topology |
-| Mobile apps | L1 + L2 + L3 (app) | App container has layers (UI, state, data, platform) |
+| Project Type | Levels |
+|---|---|
+| Libraries, SDKs, CLI tools | L1 + L2 only |
+| Web apps (monolith or frontend+API) | L1 + L2 + L3 (backend/API) |
+| Microservices / distributed | L1 + L2 + L3 + L4 |
+| Mobile apps | L1 + L2 + L3 (app layers) |
 
-Remove C4 level sections that are not applicable rather than leaving them with placeholder content.
+Remove non-applicable sections rather than leaving placeholders.
 
 ### Section guidance
 
-The sections above are a default starting point. Adapt based on the project:
+Adapt to the project: libraries may replace "Data Architecture" with "Data Flow", CLIs may add "Exit Codes" to Cross-Cutting, microservices may add "Service Discovery". Remove sections that add no value. Merge or simplify for simple projects.
 
-- **Libraries/SDKs:** Replace "Data Architecture" with "Data Flow". Omit Deployment View and Cross-Cutting Concerns if trivial.
-- **CLI tools:** "Cross-Cutting Concerns" may include "Error Output" and "Exit Codes". Omit Deployment View.
-- **Microservices:** Add "Service Communication" and "Service Discovery" under Cross-Cutting Concerns.
-- **Simple projects:** Merge or remove sections that add no value.
+**Feature integration:** Synthesize multiple feature designs into a cohesive system view without duplicating feature-specific details.
 
-Remove sections that do not apply rather than leaving them empty.
-
-**Feature integration:** When multiple feature designs exist, the architecture document synthesizes them into a cohesive system view. It shows how features relate at the system level without duplicating feature-specific design details.
-
-**Version rules:**
-- `:version:` uses SemVer, starts at `1.0.0`
-- The Feature Design Sources table records which feature design versions the architecture was synthesized from. When updating, update the table to reflect the current design versions.
-- MAJOR bump: components removed or fundamentally restructured
-- MINOR bump: components added or modified
-- PATCH bump: clarifications, formatting, metadata updates
-- Always update `:last-updated:` to today's date
+**Version rules:** MAJOR (components removed/restructured), MINOR (added/modified), PATCH (clarifications). Update Feature Design Sources table and `:last-updated:`.
 
 ## Quality Checklist
 
-Before finalizing, verify:
-- C4 System Context diagram accurately shows all users and external systems
-- C4 Container diagram includes all major runtime containers and their communication
-- C4 Component diagrams (if included) match the actual module/service structure
-- C4 Deployment diagram (if included) reflects the real infrastructure topology
-- All ADR technology decisions are reflected in Technology Stack
-- Component descriptions match the actual codebase (if one exists)
-- No empty sections remain (remove instead)
-- Data architecture covers all persistent data stores
-- Architecture constraints from `docs/constraints.adoc` are addressed
-- Feature Design Sources table lists all feature designs and their current versions
-- Version and date are updated
+- C4 diagrams accurately reflect system structure
+- All ADR decisions reflected in Technology Stack
+- Component descriptions match codebase (if one exists)
+- No empty sections (remove instead)
+- Architecture constraints from `docs/constraints.adoc` addressed
+- Feature Design Sources table current
+- Version and date updated
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing an architecture document for the e-commerce system.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-compliance/SKILL.md
+++ b/skills/needs-compliance/SKILL.md
@@ -1,123 +1,62 @@
 ---
 name: needs-compliance
-description: Verify and enforce license and policy compliance across the project. Use when the proven-needs orchestrator determines that compliance needs checking or enforcement. Operates at the project level. Observes dependency licenses, policy requirements, and regulatory constraints. Identifies violations and proposes remediations.
+description: Verify and enforce license and policy compliance across the project. Use when the proven-needs orchestrator determines that compliance needs checking or enforcement. Operates at the project level. Observes dependency licenses, identifies violations, proposes remediations.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the desired state and current state context.
+Invoked by the `proven-needs` orchestrator with desired state and current state context.
 
 ## Observe
 
-Assess the current compliance posture of the project.
-
 ### 1. Dependency license analysis
 
-For each dependency (direct and transitive):
-- Identify the declared license (from package metadata)
-- Classify the license type (permissive, copyleft, proprietary, unknown)
-
-Common license classifications:
+For each dependency (direct and transitive): identify declared license, classify type.
 
 | Category | Licenses | Typical constraint |
 |---|---|---|
-| Permissive | MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC | Generally allowed |
-| Weak copyleft | LGPL-2.1, LGPL-3.0, MPL-2.0 | May have linking restrictions |
-| Strong copyleft | GPL-2.0, GPL-3.0, AGPL-3.0 | Often restricted in proprietary projects |
-| Proprietary | Various commercial licenses | Requires license agreement |
+| Permissive | MIT, Apache-2.0, BSD-2/3-Clause, ISC | Generally allowed |
+| Weak copyleft | LGPL-2.1/3.0, MPL-2.0 | May have linking restrictions |
+| Strong copyleft | GPL-2.0/3.0, AGPL-3.0 | Often restricted in proprietary projects |
+| Proprietary | Commercial | Requires license agreement |
 | Unknown | No license declared | Risk -- may not be legally usable |
 
 ### 2. Read constraints
 
-Read `docs/constraints.adoc`. Identify licensing constraints (e.g., "Only MIT, Apache-2.0, and BSD-licensed dependencies are permitted").
+Read `docs/constraints.adoc` for licensing constraints.
 
 ### 3. Identify violations
 
-Compare each dependency's license against the licensing constraints. Flag:
-- **Direct violations** -- dependency uses a prohibited license
-- **Transitive violations** -- a dependency of a dependency uses a prohibited license
-- **Unknown licenses** -- no license metadata available
-
-### 4. Report observation
-
-Return to the orchestrator:
-```
-Compliance:
-  total-dependencies: N (direct: N, transitive: N)
-  license-distribution: {MIT: N, Apache-2.0: N, GPL-3.0: N, unknown: N, ...}
-  violations: [{package, license, constraint-violated, direct/transitive}]
-  unknown-licenses: [{package, reason}]
-```
+Compare each dependency's license against constraints. Flag: direct violations, transitive violations, unknown licenses.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Map desired state to actions
-
 | Desired State | Actions |
 |---|---|
-| "All dependencies are license-compliant" | Replace or remove violating dependencies |
-| "No unknown licenses" | Research and document unknown licenses, replace if non-compliant |
-| "Full compliance audit" | Comprehensive report of all licenses and their status |
+| "All dependencies license-compliant" | Replace or remove violating deps |
+| "No unknown licenses" | Research and document, replace if non-compliant |
+| "Full compliance audit" | Comprehensive report |
 
-### 2. Assess remediation options
-
-For each violation:
-- Is there a drop-in replacement with a compliant license?
-- Can the dependency be removed entirely?
-- Is a license exception warranted (requires constraint update)?
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: remediate / audit-only / none
-Violations: N
-Proposed remediations: [{package, current-license, action: replace/remove/exception, replacement-package}]
-Constraint updates needed: [list or none]
-```
+For each violation: is there a compliant drop-in replacement? Can the dep be removed? Is an exception warranted (requires constraint update)?
 
 ## Execute
 
 ### 1. Replace non-compliant dependencies
 
-For each approved replacement:
-1. Remove the non-compliant dependency
-2. Add the compliant replacement
-3. Update import/require statements in the codebase
-4. Run the package manager's install command
+Remove non-compliant dep, add compliant replacement, update imports, run install.
 
 ### 2. Remove unnecessary non-compliant dependencies
 
-For dependencies that can be removed:
-1. Remove the dependency
-2. Replace its usage with native/built-in alternatives or inline implementations
-3. Run the package manager's install command
+Remove dep, replace with native/built-in alternatives or inline implementations.
 
 ### 3. Document exceptions
 
-If the user approves a license exception:
-1. Record the exception in `docs/constraints.adoc` as a noted exception under the licensing section
-2. Document the rationale
+If user approves exception: record in `docs/constraints.adoc` under licensing with rationale.
 
 ### 4. Verify
 
-After all remediations:
-1. Re-run license analysis to confirm violations are resolved
-2. Run the build and test suite
-3. Verify all licensing constraints are satisfied
-
-### 5. Report results
-
-Return to the orchestrator:
-```
-Remediations applied: [{package, action, status}]
-Verification: {compliance-scan: pass/fail, build: pass/fail, tests: pass/fail}
-Constraint violations resolved: [list]
-Remaining violations: [list or none]
-```
+Re-run license analysis, run build and tests, verify all licensing constraints satisfied.
 
 ## Reference
 
-See `references/example.adoc` for an example showing a compliance audit and remediation cycle.
+See `references/example.adoc` for an example.

--- a/skills/needs-dependencies/SKILL.md
+++ b/skills/needs-dependencies/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: needs-dependencies
-description: Manage and update the project dependency graph. Use when the proven-needs orchestrator determines that dependencies need updating, patching, or auditing. Operates at the project level. Observes outdated packages, known vulnerabilities, archived/unmaintained packages, and license compliance. Executes minimal updates that satisfy the desired state while respecting all constraints.
+description: Manage and update the project dependency graph. Use when the proven-needs orchestrator determines that dependencies need updating, patching, or auditing. Operates at the project level. Observes outdated packages, vulnerabilities, unmaintained packages, and license compliance. Executes minimal updates respecting all constraints.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the desired state and current state context.
+Invoked by the `proven-needs` orchestrator with desired state and current state context.
 
 ## Observe
 
-Assess the current state of the project dependency graph.
-
 ### 1. Detect package manager
 
-Identify the project's dependency management system:
-
-| File | Package Manager |
+| File | Manager |
 |---|---|
 | `package.json` + `package-lock.json` | npm |
 | `package.json` + `bun.lock` | bun |
@@ -28,131 +24,38 @@ Identify the project's dependency management system:
 
 ### 2. Analyze dependency state
 
-For each dependency:
-- **Current version** installed
-- **Latest version** available
-- **Version constraint** in the manifest
-- **Update type** (patch / minor / major)
-- **Vulnerability status** -- check for known CVEs (use `npm audit`, `cargo audit`, `pip-audit`, or equivalent)
-- **Maintenance status** -- is the package archived, unmaintained, or deprecated?
-- **License** -- what license does the package use?
+For each dependency: current version, latest version, version constraint, update type (patch/minor/major), vulnerability status (CVEs via `npm audit`/`cargo audit`/`pip-audit`/etc.), maintenance status, license.
 
 ### 3. Read constraints
 
-Read `docs/constraints.adoc`. Identify:
-- **Security constraints** (e.g., "No dependency with a known CRITICAL or HIGH CVE may remain unpatched for more than 7 days")
-- **Licensing constraints** (e.g., "Only MIT, Apache-2.0, and BSD-licensed dependencies are permitted")
-
-### 4. Report observation
-
-Return to the orchestrator:
-```
-Dependencies:
-  total: N
-  outdated: N (patch: N, minor: N, major: N)
-  vulnerable: N (critical: N, high: N, medium: N, low: N)
-  unmaintained: N
-  license-violations: N
-Constraint violations:
-  security: [list]
-  licensing: [list]
-```
+Read `docs/constraints.adoc` for security constraints (CVE timelines) and licensing constraints.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Map desired state to actions
-
 | Desired State | Actions |
 |---|---|
-| "No known vulnerabilities" | Update vulnerable dependencies to patched versions |
-| "All dependencies up to date" | Update all outdated dependencies |
-| "No unmaintained dependencies" | Identify replacements for archived packages |
-| "License compliance" | Replace or remove license-violating dependencies |
-| Specific: "Update lodash" | Update the named dependency |
+| "No known vulnerabilities" | Update vulnerable deps to patched versions |
+| "All dependencies up to date" | Update all outdated deps |
+| "No unmaintained dependencies" | Identify replacements |
+| "License compliance" | Replace or remove violations |
+| Specific package update | Update the named dependency |
 
-### 2. Assess risk per update
-
-| Update Type | Risk Level | Auto-approve eligible? |
-|---|---|---|
-| Patch (x.y.Z) | Low | Yes |
-| Minor (x.Y.z) | Medium | Only if tests pass |
-| Major (X.y.z) | High | No -- requires user approval |
-| Replacement (different package) | High | No -- requires user approval |
-
-### 3. Check constraints
-
-- Would any update introduce a license violation?
-- Would any update break API compatibility constraints?
-- Are there security constraints that make this update mandatory?
-
-### 4. Report evaluation
-
-Return to the orchestrator:
-```
-Action: update / replace / none
-Updates proposed: [{package, from, to, type, risk}]
-Replacements proposed: [{old-package, new-package, reason}]
-Constraint resolution: [which constraint violations would be resolved]
-Constraint risks: [which constraints might be affected]
-```
+Risk levels follow the orchestrator's classification (patch=low, minor=medium, major=high). Patch updates are auto-approve eligible. Major updates and replacements require user approval.
 
 ## Execute
 
-```mermaid
-flowchart TD
-    UPDATES["Proposed updates"] --> TYPE{"Update<br/>type?"}
-
-    TYPE -->|"Patch (x.y.Z)"| LOW["Low risk<br/>→ auto-approve"]
-    TYPE -->|"Minor (x.Y.z)"| MED["Medium risk<br/>→ approve if tests pass"]
-    TYPE -->|"Major (X.y.z)"| HIGH["High risk<br/>→ require user approval"]
-    TYPE -->|"Replacement<br/>(different package)"| HIGH
-
-    LOW --> APPLY["Apply update"]
-    MED --> APPLY
-    HIGH -->|Approved| APPLY
-
-    APPLY --> VERIFY{"Verify<br/>(build / lint / test)"}
-    VERIFY -->|Pass| RECHECK["Re-check constraints<br/>(vuln audit, licenses)"]
-    VERIFY -->|Fail| ROLLBACK["Roll back<br/>problematic update"]
-    ROLLBACK --> REPORT["Report failure"]
-
-    RECHECK --> DONE["Report results"]
-```
-
 ### 1. Apply updates
 
-For each approved update:
-1. Update the version in the manifest file
-2. Run the package manager's install/update command
-3. Verify the lockfile is updated
+For each approved update: update version in manifest, run install/update, verify lockfile.
 
 ### 2. Verify
 
-After all updates:
-1. Run the build
-2. Run the linter/type checker
-3. Run the test suite
-4. If any verification fails, roll back the problematic update and report
+Run build, linter, test suite. Roll back problematic updates if verification fails.
 
 ### 3. Constraint re-check
 
-After verification passes:
-- Re-run vulnerability audit -- confirm violations are resolved
-- Re-check license compliance
-- Confirm no new constraint violations introduced
-
-### 4. Report results
-
-Return to the orchestrator:
-```
-Updates applied: [{package, from, to, status: success/failed}]
-Verification: {build: pass/fail, lint: pass/fail, tests: pass/fail}
-Constraint violations resolved: [list]
-Remaining issues: [list or none]
-```
+Re-run vulnerability audit, re-check license compliance, confirm no new violations.
 
 ## Reference
 
-See `references/example.adoc` for an example showing a dependency audit and update cycle.
+See `references/example.adoc` for an example.

--- a/skills/needs-design/SKILL.md
+++ b/skills/needs-design/SKILL.md
@@ -1,208 +1,77 @@
 ---
 name: needs-design
-description: Create and maintain implementation design documents for a feature. Use when the proven-needs orchestrator determines that a feature needs a design created, updated, or synced with upstream changes. Operates within a single feature package at docs/features/<slug>/. The design document is a living document that explains HOW the feature works — the implementation blueprint that solves the user stories, constrained by the specs and project-wide ADRs. It stays in sync with stories and specs throughout the feature's lifecycle. Each feature design is fully independent and can be implemented without reading other feature designs.
+description: Create and maintain implementation design documents for a feature. Use when the proven-needs orchestrator determines that a feature needs a design created, updated, or synced with upstream changes. Operates within a single feature package at docs/features/<slug>/. The design document explains HOW — the implementation blueprint constrained by specs and ADRs. Each feature design is independent.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
-During Phase 0 (Research and Decisions), this skill loads the `needs-adr` skill directly when the user confirms that a technology decision should be recorded as an ADR. This is the one case where a capability skill loads another capability skill without routing through the orchestrator -- because the ADR creation is part of the design research phase, not a separate transition step.
+During Phase 0 (Research), this skill loads `needs-adr` directly when the user confirms a technology decision should be recorded as an ADR.
 
 ## Observe
 
-Assess the current state of the design for this feature.
-
-### 1. Read feature stories
-
-Read `docs/features/<slug>/user-stories.adoc`. Extract `:version:`, all stories, acceptance criteria.
-
-**If missing:** Report to the orchestrator that stories are missing. The orchestrator decides whether to create them first.
-
-### 2. Read feature spec
-
-Read `docs/features/<slug>/spec.adoc`. Extract `:version:`, all requirement IDs and texts.
-
-**If missing:** Report to the orchestrator that specifications are unavailable. The orchestrator should invoke `needs-spec` first -- every feature gets a specification. As a fallback (e.g., partial transition recovery), the design can proceed with story-level acceptance criteria only. If proceeding without spec: set `:source-spec-version:` to `n/a` in the design output.
-
-### 3. Read project-wide artifacts
-
-- **`docs/adrs/`** -- read all ADRs with status `Accepted`. These are technology constraints.
-- **`docs/constraints.adoc`** -- read all constraints, particularly architecture and quality constraints.
-- **`docs/architecture.adoc`** -- if it exists, understand the current system architecture for context.
-
-### 4. Read existing design
-
-If `docs/features/<slug>/design.adoc` exists:
-- Read `:version:`, `:status:`, `:source-stories-version:`, `:source-spec-version:`
-- Read the full design content
-
-### 5. Analyze codebase
-
-If this is not a greenfield project, analyze the current code structure to understand what already exists. Look at directory structure, key source files, configuration files, and existing patterns.
-
-### 6. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Stories: {exists: true, version: "X.Y.Z"}
-Spec: {exists: true/false, version: "X.Y.Z"}
-Design: {exists: true/false, version: "X.Y.Z", status: "Current/Stale"}
-ADRs: {count: N, accepted: N}
-Constraints: {count: N, architecture: N, quality: N}
-Codebase: {type: "TypeScript/Next.js", existing-patterns: [...]}
-```
+1. Read `docs/features/<slug>/user-stories.adoc`: extract `:version:`, all stories, acceptance criteria. If missing, report to orchestrator.
+2. Read `docs/features/<slug>/spec.adoc`: extract `:version:`, all requirement IDs and texts. If missing, note it; design can proceed from stories only (set `:source-spec-version: n/a`).
+3. Read project-wide artifacts: `docs/adrs/` (accepted ADRs), `docs/constraints.adoc` (architecture/quality constraints), `docs/architecture.adoc` (current system context).
+4. If `docs/features/<slug>/design.adoc` exists: read `:version:`, `:status:`, source versions, full content.
+5. Analyze codebase for existing patterns (non-greenfield only).
 
 ## Evaluate
-
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require design changes?
 
 | Condition | Action |
 |---|---|
 | No design exists | Create new design |
-| Design exists, source versions match current stories and spec | Design appears current. Report to orchestrator. |
-| Design exists, source versions differ | Design is stale. Sync with upstream changes (incremental update or full redesign). |
+| Design exists, source versions match | Report current to orchestrator |
+| Design exists, source versions differ | Stale -- sync needed |
 
-### 2. Check constraints
-
-- Verify proposed design elements against architecture constraints
-- Verify design decisions respect ADR decisions
-- Flag any constraint conflicts
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / sync / none
-Constraint conflicts: [list or none]
-Technology decisions needed: [list or none]
-```
+Check proposed design against architecture constraints and ADR decisions. Flag conflicts.
 
 ## Execute
 
-```mermaid
-flowchart TD
-    START["Execute design"] --> P0["Phase 0: Research"]
-
-    subgraph phase0 ["Phase 0 — Research and Decisions"]
-        P0 --> TECH["Identify technology<br/>decisions needed"]
-        P0 --> UNKN["Identify unknowns<br/>and dependencies"]
-        P0 --> EXIST["Analyze existing<br/>system (if non-greenfield)"]
-
-        TECH --> ADR{"ADR exists<br/>for decision?"}
-        ADR -->|Yes| REUSE["Reuse existing ADR"]
-        ADR -->|No| CREATE["Create ADR<br/>(via needs-adr)"]
-
-        UNKN --> RESOLVE["Resolve unknowns<br/>with user"]
-    end
-
-    REUSE --> P1
-    CREATE --> P1
-    RESOLVE --> P1
-    EXIST --> P1
-
-    P1["Phase 1: Design"]
-    subgraph phase1 ["Phase 1 — Design"]
-        P1 --> SYS["System design<br/>+ Mermaid diagrams"]
-        P1 --> DATA["Data model<br/>(if applicable)"]
-        P1 --> IFACE["Interface contracts<br/>(if applicable)"]
-        P1 --> STORY["Story resolution<br/>(map stories → design)"]
-    end
-
-    SYS --> WRITE["Write design files"]
-    DATA --> WRITE
-    IFACE --> WRITE
-    STORY --> WRITE
-```
-
 ### Phase 0: Research and Decisions
 
-Analyze all user stories and specs (if available) to identify:
+Analyze stories and specs to identify:
 
-1. **Technology decisions needed** -- for each story, what technology choices are required? Cross-reference against existing ADRs:
-   - "US-003 requires persistent storage -- which database?" (if no ADR exists)
-   - "US-005 requires real-time updates -- WebSocket or SSE?" (if no ADR exists)
+1. **Technology decisions** -- cross-reference against existing ADRs. For each decision not covered by an ADR:
+   - Present to user with context, alternatives, and recommendation
+   - If user says "create ADR" → load `needs-adr` and create it before proceeding
+   - If not → record in design's "Decisions and Constraints" section as unrecorded decision
 
-2. **Unknowns and dependencies** -- external systems, third-party services, constraints needing clarification.
+2. **Unknowns and dependencies** -- resolve with user or list as open questions.
 
-3. **Existing system analysis** (non-greenfield only) -- how is the current system structured? What patterns does it use? What can be reused vs. modified?
+3. **Existing system analysis** (non-greenfield) -- patterns, reusable code, integration points.
 
-**For each technology decision not covered by an existing ADR:**
-1. Present the decision to the user with context, alternatives considered, and a recommendation
-2. Ask the user: "Should I create an ADR for this decision?"
-3. **If yes:** Load the `needs-adr` skill and create the ADR before proceeding. The design document will reference the new ADR (e.g., `<<../../adrs/NNNN-decision-title.adoc#,ADR-NNNN>>`).
-4. **If no:** Record the decision in the design's "Decisions and Constraints" section with a brief rationale, but note that it is an unrecorded decision (not an ADR).
-
-**Do NOT skip this step.** Technology decisions made during design are the primary source of ADRs. If Phase 0 identifies decisions and the user agrees to create ADRs, the ADRs must be created before moving to Phase 1, so the design document can reference them.
-
-**For each unknown:**
-- Present it to the user as an open question
-- Resolve before proceeding to Phase 1, or explicitly list as an open question in the design
+Do NOT skip this step. Technology decisions are the primary source of ADRs.
 
 ### Phase 1: Design
 
-Design the solution that solves the user stories while satisfying the specs (when available) and respecting all constraints.
-
-**The design structure is adaptive.** Choose an organization appropriate for the project type. The sections below are guidance, not a rigid template.
+Design the solution satisfying stories, specs (when available), and constraints. Structure is adaptive to the project type.
 
 #### System design
 
-Describe the major components, modules, or services for this feature. For each:
-- Its responsibility (what it does)
-- Its interfaces (how other components interact with it)
-- Key implementation details
+Describe components, modules, or services. For each: responsibility, interfaces, key details. Include Mermaid diagrams:
 
-Include Mermaid diagrams to clarify component relationships and key flows:
+- **Component interaction** (`flowchart`) -- required for every design
+- **Sequence diagram** (`sequenceDiagram`) -- for multi-component flows
+- **State diagram** (`stateDiagram-v2`) -- for stateful entities
+- **Data flow** (`flowchart`) -- when data path is non-obvious
 
-- **Component interaction diagram** (`flowchart`) -- at minimum one diagram showing how the feature's components relate and communicate. Required for every design.
-- **Sequence diagram** (`sequenceDiagram`) -- for the primary user flow through the feature. Include when the flow involves multiple components or has non-obvious ordering.
-- **State diagram** (`stateDiagram-v2`) -- for entities with meaningful state transitions (e.g., order lifecycle, session states). Include when the feature manages stateful entities.
-- **Data flow diagram** (`flowchart`) -- when data moves through multiple components or transformations. Include when the data path is not obvious from the component diagram alone.
+Embed in AsciiDoc `[source,mermaid]` blocks. Structure depends on project type (web app: frontend/backend/DB/API; CLI: parser/logic/formatters; library: public API/internals/extensions; etc.).
 
-Embed diagrams inline in the relevant design sections using AsciiDoc `[source,mermaid]` blocks. Note: these render as syntax-highlighted code blocks on GitHub; full diagram rendering requires an Asciidoctor-compatible viewer with the `asciidoctor-diagram` extension.
-
-The structure depends on the project:
-
-| Project Type | Typical Structure |
-|---|---|
-| Web application | Frontend components, backend services, database, API layer |
-| CLI tool | Command parser, core logic modules, output formatters |
-| Library/SDK | Public API surface, internal modules, extension points |
-| Microservices | Service boundaries, communication patterns, shared infrastructure |
-| Mobile app | Screens/views, state management, data layer, platform services |
-
-**Independence rule:** The design must not depend on or reference other feature designs. It may reference project-wide ADRs and architecture.
+**Independence rule:** Design must not reference other feature designs. May reference ADRs and architecture.
 
 #### Data model
 
-If the feature involves persistent or structured data:
-- Entities and their attributes
-- Relationships between entities
-- Validation rules derived from specs
-- State transitions (if applicable)
-
-Write this to a separate file `docs/features/<slug>/data-model.adoc` when the data model is non-trivial.
+If the feature involves persistent data: entities, attributes, relationships, validation rules, state transitions. Write to `docs/features/<slug>/data-model.adoc` when non-trivial.
 
 #### Interface contracts
 
-If the feature exposes external interfaces:
-- What interfaces exist (APIs, CLI commands, library exports, UI contracts)
-- Input/output formats
-- Error responses
-
-Write these to `docs/features/<slug>/contracts/` when relevant.
+If the feature exposes external interfaces: formats, inputs/outputs, errors. Write to `docs/features/<slug>/contracts/` when relevant.
 
 #### Story resolution
 
-For each user story in this feature, describe:
-- **Which components are involved** in solving this story
-- **How the acceptance criteria are met** by the design
-- **Which spec IDs are satisfied** by which design elements (when specs are available)
-
-This section is the proof that the design solves the stories. Every user story must appear here. When specs are available, every spec ID must be mapped to at least one design element. When specs are not available (`:source-spec-version:` is `n/a`), map acceptance criteria directly to design elements instead.
+For each user story: which components are involved, how acceptance criteria are met, which spec IDs are satisfied. Every story must appear. When specs available, every spec ID must map to a design element.
 
 ### Write design files
 
@@ -219,164 +88,57 @@ Create `docs/features/<slug>/design.adoc`:
 :toc:
 
 == Technical Context
-
-<Project overview. Greenfield or existing system. Current state relevant to this feature.>
+<Project overview. Current state relevant to this feature.>
 
 == Decisions and Constraints
-
-<References to relevant ADRs. Summary of technology decisions made during Phase 0.>
-
-* <<../../adrs/0001-use-typescript.adoc#,ADR-0001>>: Use TypeScript
-* <<../../adrs/0002-use-postgresql.adoc#,ADR-0002>>: Use PostgreSQL
+<ADR references. Technology decisions from Phase 0.>
 
 == Research and Unknowns
-
-<Findings from Phase 0. Resolved unknowns. Any remaining open questions.>
+<Phase 0 findings. Resolved unknowns. Open questions.>
 
 == System Design
-
-<Adaptive structure -- components, modules, services, data flow.
- Organized appropriately for the project type.
- Scoped to this feature only.
- Include Mermaid diagrams: at minimum a component interaction diagram
- for the primary flow. Add sequence, state, or data flow diagrams
- where they clarify complex interactions.>
+<Components, modules, services. Mermaid diagrams.>
 
 == Story Resolution
 
 === US-001: <Title>
-
-Components:: <which components are involved>
+Components:: <involved components>
 Criteria::
-* <acceptance criterion> -> <how the design meets it> (SPEC-ID)
-* ...
-
-=== US-002: <Title>
-
-Components:: <which components are involved>
-Criteria::
-* ...
+* <criterion> -> <how design meets it> (SPEC-ID)
 ```
 
-**`:status:` values:**
-- `Current` -- design is valid and aligned with stories and specs
-- `Stale` -- upstream stories or specs have changed since this design was created; sync needed
+**`:status:` values:** `Current` (aligned with upstream), `Stale` (upstream changed, sync needed).
 
-**Version rules:**
-- `:version:` uses SemVer, starts at `1.0.0`
-- `:source-stories-version:` records which user stories version was used
-- `:source-spec-version:` records which spec version was used; set to `n/a` if spec was skipped
-- `:last-updated:` set to today's date
+### Sync workflow (design already exists)
 
-**Additional files (when applicable):**
-- `docs/features/<slug>/data-model.adoc` -- entity/data model
-- `docs/features/<slug>/contracts/` -- interface contract files
-
-### Sync workflow (when design already exists)
-
-The design is a living document that stays in sync with stories and specs. When upstream artifacts change, the design is updated to reflect the new reality.
-
-```mermaid
-flowchart TD
-    START["Sync triggered"] --> STALE{"Quick staleness check:<br/>source versions ≠<br/>current versions?"}
-
-    STALE -->|No| CURRENT["Design appears current<br/>→ report to orchestrator"]
-    STALE -->|Yes| DIFF["Content-based<br/>change analysis"]
-
-    DIFF --> NEW["New stories/specs<br/>→ need design coverage"]
-    DIFF --> MOD["Modified stories/specs<br/>→ update design sections"]
-    DIFF --> REM["Removed stories/specs<br/>→ orphaned design sections"]
-
-    NEW --> REPORT["Present change<br/>report to user"]
-    MOD --> REPORT
-    REM --> REPORT
-
-    REPORT --> DECIDE{"User decides"}
-    DECIDE -->|Incremental| INCR["Apply incremental<br/>updates"]
-    DECIDE -->|Full redesign| FULL["Redesign from<br/>scratch"]
-
-    INCR --> BUMP["Version bump<br/>+ update source versions<br/>+ set status: Current"]
-    FULL --> BUMP
-```
-
-#### Quick staleness check
-
-Compare `:source-stories-version:` and `:source-spec-version:` in `design.adoc` against the current versions of `user-stories.adoc` and `spec.adoc`. If versions match, inform the orchestrator that the design appears current.
-
-#### Content-based change analysis
-
-1. Read current stories and specs
-2. Compare against the design's Story Resolution section
-3. Identify:
-   - **New stories/specs** -- not covered by the design
-   - **Modified stories/specs** -- design elements need updating
-   - **Removed stories/specs** -- design elements are orphaned
-
-#### Present change report
-
-```
-Design sync: stories 1.0.0 -> 1.1.0, spec 1.0.0 -> 1.1.0
-
-Added:
-  - US-003 needs new components and story resolution entry
-  - CART-009, CART-010 need design coverage
-
-Modified:
-  - US-001 criteria changed -- CartService logic needs revision
-
-Removed:
-  - US-002 removed -- Cart Page and related design sections orphaned
-
-Sections unaffected: Technical Context, Decisions and Constraints
-```
-
-Ask the user whether to apply incrementally or redesign from scratch.
-
-#### Apply changes
-
-1. **Preserve stable sections:** Keep design sections unaffected by changes.
-2. **Update affected sections:** Modify design sections impacted by changed stories or specs.
-3. **Remove orphaned sections:** Remove design elements that existed solely for removed stories.
-4. **Update Story Resolution:** Re-map all stories, ensuring every current story and spec ID is accounted for.
-5. **Bump version:** MAJOR if elements removed, MINOR if added/modified, PATCH if metadata only.
-6. **Update source versions:** Set `:source-stories-version:` and `:source-spec-version:` to current. Set `:status:` to `Current`. Update `:last-updated:`.
+1. **Quick staleness check** -- compare source versions against current stories/spec versions.
+2. **Content analysis** -- identify new, modified, and removed stories/specs.
+3. **Present change report** -- ask user: incremental update or full redesign.
+4. **Apply changes** -- preserve stable sections, update affected ones, remove orphaned ones, re-map Story Resolution. Bump version (MAJOR if removed, MINOR if added/modified, PATCH if metadata). Set `:status: Current`.
 
 ### Post-implementation reconciliation
 
-This mode is invoked by the orchestrator after `needs-implementation` reports design divergences and the user has decided which divergences should be resolved by updating the design (vs. fixing the code).
+Invoked by the orchestrator after `needs-implementation` reports divergences where the user chose "update design".
 
-The orchestrator passes:
-- The list of divergences where the user chose "update design"
-- For each: what the design specified, what was implemented, and the rationale
-
-**Steps:**
-
-1. For each divergence routed to this skill:
-   a. Locate the relevant design sections (system design, story resolution, data model, contracts)
-   b. Update the design to accurately reflect what was built
-   c. Ensure the Story Resolution section still correctly maps stories to design elements
-2. Verify that the updated design remains internally consistent (no orphaned references, no contradictions between sections)
-3. Bump version: PATCH if minor clarifications, MINOR if substantive structural changes
-4. Keep `:status:` as `Current` -- the design remains a living document
-5. Update `:last-updated:` to today's date
+For each routed divergence:
+1. Locate and update relevant design sections
+2. Ensure Story Resolution remains consistent
+3. Verify no orphaned references or contradictions
+4. Bump version (PATCH for minor clarifications, MINOR for structural changes)
+5. Keep `:status: Current`
 
 ## Quality Checklist
 
-Before finalizing, verify:
-- Every user story in this feature is addressed in Story Resolution
-- Every spec ID is mapped to at least one design element (skip if `:source-spec-version:` is `n/a`)
-- All ADR decisions are respected in the design
-- All architecture constraints from `docs/constraints.adoc` are satisfied
-- No unresolved unknowns remain (or are explicitly listed)
-- Design is implementable (specific enough to code from)
-- Design does not depend on other feature designs
-- Source versions are recorded correctly
-- Data model covers all entities implied by the stories (if applicable)
-- Interface contracts match the spec requirements (if applicable)
-- At least one Mermaid component interaction diagram is included in System Design
-- Diagrams accurately reflect the components and flows described in prose
-- Sequence diagrams cover the primary user flow (when the flow involves multiple components)
+- Every user story addressed in Story Resolution
+- Every spec ID mapped to a design element (skip if `:source-spec-version: n/a`)
+- ADR decisions respected
+- Architecture constraints satisfied
+- No unresolved unknowns (or explicitly listed)
+- Design is implementable
+- No cross-feature design dependencies
+- Source versions recorded correctly
+- At least one Mermaid component interaction diagram included
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing how a feature's stories and specs become a design document with story resolution mapping.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-implementation/SKILL.md
+++ b/skills/needs-implementation/SKILL.md
@@ -1,249 +1,114 @@
 ---
 name: needs-implementation
-description: Implement code for a feature from its task list or design. Use when the proven-needs orchestrator determines that a feature needs code implementation. Operates within a single feature package at docs/features/<slug>/. Reads the feature's tasks and design to produce working code, one phase at a time. After each phase, verifies the build, commits, and asks the user before proceeding.
+description: Implement code for a feature from its task list or design. Use when the proven-needs orchestrator determines that a feature needs code implementation. Operates within a single feature package at docs/features/<slug>/. Reads tasks and design to produce working code, one phase at a time.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
 ## Observe
 
-Assess the current state of implementation for this feature.
-
-### 1. Read feature task list
-
-Read `docs/features/<slug>/tasks.adoc`. Extract `:version:`, `:status:`, all phases, all tasks with metadata (Components, Stories, Specs, Description, parallel/sequential markers, tick states).
-
-**If missing:** Check whether `docs/features/<slug>/design.adoc` exists. If so, note that implementation will follow the design's Story Resolution section story-by-story (no phased execution). If neither tasks nor design exist, report to the orchestrator that at minimum a design is needed.
-
-### 2. Read feature design
-
-Read `docs/features/<slug>/design.adoc`. Extract system design sections, story resolution mappings, architectural decisions. Also read `data-model.adoc` and files in `contracts/` if they exist.
-
-**If missing:** Note that implementation will lack architectural guidance.
-
-### 3. Read feature stories and spec
-
-- **`docs/features/<slug>/user-stories.adoc`** -- for context on acceptance criteria.
-- **`docs/features/<slug>/spec.adoc`** -- for testable requirements context.
-
-### 4. Read project-wide artifacts
-
-- **`docs/constraints.adoc`** -- identify quality, architecture, and performance constraints that apply during implementation.
-- **`docs/adrs/`** -- technology decisions that affect implementation choices.
-
-### 5. Analyze codebase
-
-Analyze current code structure, existing patterns, frameworks, and conventions to ensure new code is consistent.
-
-### 6. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Tasks: {exists: true/false, status: "Current/Stale/Implemented", progress: "N/M ticked", phases: N}
-Design: {exists: true/false, status: "Current/Stale"}
-Implementation: {started: true/false, phases-complete: N, current-phase: N}
-Codebase: {conventions: [...], build-status: pass/fail, test-status: pass/fail}
-```
+1. Read `docs/features/<slug>/tasks.adoc`: `:version:`, `:status:`, phases, tasks with metadata. If missing, check if `design.adoc` exists (story-by-story implementation). If neither exists, report to orchestrator.
+2. Read `docs/features/<slug>/design.adoc`: system design, story resolution, data model, contracts.
+3. Read `user-stories.adoc` and `spec.adoc` for context.
+4. Read `docs/constraints.adoc` (quality, architecture, performance) and `docs/adrs/` (technology decisions).
+5. Analyze codebase for conventions, patterns, build status, test status.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require implementation?
-
 | Condition | Action |
 |---|---|
-| No tasks exist, no design exists | Cannot implement. Report to orchestrator. |
-| Tasks exist, `:status:` is `Implemented` | Already complete. Report to orchestrator. |
-| Tasks exist, `:status:` is `Stale` | Warn that task list is stale. Ask orchestrator whether to proceed or update tasks first. |
-| Tasks exist, some ticked | Partial progress. Determine resume point. |
-| Tasks exist, none ticked | Start from Phase 1. |
-| No tasks, design exists | Story-by-story implementation from design. |
-
-### 2. Check constraints
-
-- Quality constraints: tests required? coverage thresholds?
-- Architecture constraints: code organization rules?
-- Performance constraints: response time requirements?
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: implement / resume / story-by-story / none
-Start point: Phase N / Story US-NNN
-Constraint requirements: [testing, coverage threshold, architecture rules]
-```
+| No tasks, no design | Cannot implement, report |
+| Tasks `:status: Implemented` | Already complete, report |
+| Tasks `:status: Stale` | Warn, ask orchestrator: proceed or update tasks first |
+| Tasks, some ticked | Resume from next unticked |
+| Tasks, none ticked | Start Phase 1 |
+| No tasks, design exists | Story-by-story from design |
 
 ## Execute
 
-```mermaid
-flowchart TD
-    START["Start implementation"] --> PHASE["Phase N"]
-
-    subgraph loop ["Per-phase loop"]
-        PHASE --> TODO["1. Build phase<br/>todo list"]
-        TODO --> IMPL["2. Implement tasks<br/>(sequential / parallel)"]
-        IMPL --> VERIFY{"3. Verify<br/>(build / lint / test)"}
-        VERIFY -->|Fail| FIX["Fix issues"] --> VERIFY
-        VERIFY -->|Pass| COMMIT["4. Commit phase"]
-        COMMIT --> MORE{"More<br/>phases?"}
-        MORE -->|"Yes (user: continue)"| NEXT["Next phase"] --> TODO
-    end
-
-    MORE -->|"No / user: stop"| FINAL{"All phases<br/>complete?"}
-    FINAL -->|No| SAVE["Save progress<br/>in tasks.adoc"]
-    FINAL -->|Yes| MARK["Mark status:<br/>Implemented"]
-    MARK --> DIVERGE["Detect design<br/>divergences"]
-    DIVERGE --> REPORT["Report to<br/>orchestrator"]
-```
-
 ### Phase-by-phase implementation (from task list)
 
-Steps 1--5 repeat for each phase.
+Repeat for each phase:
 
 #### 1. Build phase todo list
 
-Parse the tasks for the **current phase only** from the feature's `tasks.adoc`. Create a tracking list. If a todo-list tool is available (e.g., TodoWrite), use it. Otherwise, track by ticking tasks in `tasks.adoc`.
-
-- Each task title becomes a todo item, prefixed with its task ID
-- All items start as `pending`
-- Do **not** include tasks from other phases
+Parse current phase tasks. Use todo-list tool if available. Do not include tasks from other phases.
 
 #### 2. Implement current phase
 
-Work through tasks following the task list exactly. Do not skip, reorder, or add tasks.
+Work through tasks exactly as listed. For each: mark in-progress, read referenced design sections, implement, mark completed, tick `[x]` in `tasks.adoc`.
 
-**For each task:**
-
-1. Mark the task as `in_progress`
-2. Read the design document sections referenced in the task's `Components::` field
-3. Implement the code as described in the task's `Description::` and informed by the design
-4. Mark the task as `completed`
-5. Tick the task `[x]` in `docs/features/<slug>/tasks.adoc`
-
-**Ordering within a phase:**
 - **`[sequential]`** tasks: implement in order
-- **`[parallel]`** tasks: may be implemented in any order
+- **`[parallel]`** tasks: any order
 
-**Implementation principles:**
-- Follow the design document for architecture, component structure, data model, and contracts
-- Follow the task description for scope -- implement exactly what it describes, nothing more
-- Match existing codebase conventions (naming, file structure, patterns, formatting)
-- Write production-quality code -- no placeholders, no TODOs, no stubs (unless the task explicitly calls for one)
-- Respect all constraints from `docs/constraints.adoc` (architecture rules, quality standards)
+**Principles:** follow design for architecture/structure, follow task description for scope, match codebase conventions, write production-quality code (no placeholders/TODOs/stubs), respect all constraints.
 
 #### 3. Verify phase
 
-After all tasks in the current phase are implemented:
-
-1. Detect the project's verification commands by checking for `package.json`, `Makefile`, `Cargo.toml`, `pyproject.toml`, or similar
-2. Run the build/compile step
-3. Run the linter/type checker if available
-4. **Run the spec-derived feature tests.** `needs-tests` has already generated tests from the spec before implementation started -- these are the acceptance gate. Run them and check which pass. Newly passing tests confirm that tasks in this phase are correctly implemented. Still-failing tests indicate remaining work for subsequent phases.
-5. Run the full test suite to ensure no regressions in other features
-6. If build, lint, or regression tests fail, fix before proceeding
-
-**Constraint verification:**
-- Check that quality constraints are satisfied (e.g., test coverage hasn't decreased)
-- Check that architecture constraints are respected (e.g., business logic in service layer)
+1. Run build/compile
+2. Run linter/type checker
+3. Run spec-derived feature tests (generated by `needs-tests` before implementation). Newly passing tests confirm correct implementation. Still-failing tests indicate remaining work.
+4. Run full test suite for regression check
+5. Fix any failures before proceeding
 
 #### 4. Commit phase
 
-After verification passes:
-
-1. Stage all new and modified files relevant to this phase
-2. Create a commit: `feat(<feature-slug>): implement phase N -- <Phase Name>` with a body listing completed task IDs
-3. If commit fails due to GPG signing, inform user and wait for retry confirmation
+Stage relevant files. Commit: `feat(<feature-slug>): implement phase N -- <Phase Name>` with body listing completed task IDs.
 
 #### 5. Ask to continue
 
-**If more phases remain:**
-Present options:
-- "Continue to Phase N: \<Phase Name\>"
-- "Stop here" -- progress is saved in `tasks.adoc`
+If more phases: offer "Continue to Phase N" or "Stop here" (progress saved in `tasks.adoc`).
 
-**If all phases are complete:**
-1. **Run all spec-derived feature tests and confirm they pass.** All tests generated by `needs-tests` must pass before the feature is considered implemented. If any spec-derived tests still fail, report the failures -- implementation is not complete.
-2. Set `:status: Implemented` in `docs/features/<slug>/tasks.adoc`
-3. Detect design divergences (see below)
-4. Update `:last-updated:` to today's date in updated files
-5. Commit task status updates
-6. Report to the orchestrator that implementation is complete, along with the test results and any divergence report
+If all phases complete:
+1. Run all spec-derived tests -- ALL must pass. If any fail, implementation is not complete.
+2. Set `:status: Implemented` in `tasks.adoc`
+3. Detect design divergences (mandatory, see below)
+4. Commit status updates
+5. Report to orchestrator with test results and divergence report
 
-#### Design divergence detection
+### Design divergence detection
 
-**This step is MANDATORY after all phases complete. Do not skip it.**
+**MANDATORY after all phases complete. Do not skip.**
 
-Re-read the feature's design document and compare section-by-section against the actual implementation:
+1. Re-read `design.adoc` in full (do not rely on memory).
+2. Compare each System Design section against actual implementation: components, interfaces, data flow, technology choices. Note additions, omissions, structural changes.
+3. Compare each Story Resolution entry against implementation.
+4. Compare `data-model.adoc` and `contracts/` against actual code (if they exist).
+5. **Produce a report -- even if no divergences found.** An explicit "No divergences detected" confirms the check was performed.
 
-1. **Re-read `docs/features/<slug>/design.adoc` in full.** Do not rely on memory of what the design said -- read the file again now.
-2. **For each section in System Design:**
-   a. Identify what the design specified (components, interfaces, data flow, technology choices)
-   b. Compare against what was actually implemented in code
-   c. Note any differences: additions not in the design, omissions from the design, structural changes, different technology choices
-3. **For each entry in Story Resolution:**
-   a. Verify the implementation satisfies the criteria as designed
-   b. Note any differences in approach or component usage
-4. **If `data-model.adoc` or `contracts/` files exist:** Compare those against the actual data schema and interfaces in code.
-5. **Produce a divergence report -- even if no divergences were found.** An explicit "No divergences detected" confirms the check was performed.
-
-For each divergence found:
-
-1. **Describe the divergence:** What the design specified vs. what was actually built
-2. **Analyze both resolution directions:**
-   - **Update design:** Explain why updating the design to match the implementation makes sense (e.g., "the design described a separate CartService, but in practice the logic was simpler and fit directly in the route handler")
-   - **Fix code:** Explain why adjusting the implementation to match the design makes sense (e.g., "the architecture constraint requires business logic in the service layer, not route handlers")
-3. **Provide context:** Why the implementation diverged -- was it a practical constraint, a better approach discovered during coding, a misunderstanding in the design, or an oversight?
-
-Report all divergences to the orchestrator in a structured format:
+For each divergence:
+- Describe: design specified vs. actually built
+- Analyze both directions: why updating design makes sense, why fixing code makes sense
+- Provide context: why the divergence occurred
 
 ```
 Design divergences for <slug>:
 
   1. CartService validation placement
-     Design: Validation logic in CartService.addItem()
-     Implementation: Validation in POST /api/cart route handler
-     Reason: Zod schema validation felt more natural at the API boundary
-     Update design: Reflect route-level validation pattern (aligns with how other routes work)
-     Fix code: Move validation into CartService (satisfies architecture constraint: business logic in service layer)
+     Design: Validation in CartService.addItem()
+     Implementation: Zod validation in POST /api/cart handler
+     Reason: Zod at API boundary is more idiomatic
+     Update design: Reflects route-level validation pattern
+     Fix code: Satisfies architecture constraint (business logic in service layer)
 
-  2. ...
-
-(or: "No divergences detected.")
+  (or: "No divergences detected.")
 ```
 
-The orchestrator presents this to the user for decision-making. This skill does NOT modify `design.adoc` -- design updates are routed to `needs-design` by the orchestrator.
+This skill does NOT modify `design.adoc` -- updates are routed to `needs-design` by the orchestrator.
 
-### Story-by-story implementation (when no task list exists)
+### Story-by-story implementation (no task list)
 
-When implementing directly from the design without a task list:
+1. Read Story Resolution from `design.adoc`
+2. Implement one story at a time, in order. Extend shared components rather than duplicate.
+3. Verify after each story (build, lint, test)
+4. Commit per story: `feat(<feature-slug>): implement US-NNN -- <Title>`
+5. Ask to continue after each story
+6. After all stories: detect divergences (same process as above), report to orchestrator
 
-1. **Read the Story Resolution section** of the feature's `design.adoc`.
-
-2. **Implement one story at a time**, in order. For each story:
-   a. Create a tracking list for the story
-   b. Read `Components::` and `Criteria::` fields
-   c. Implement all design elements mapped to the story's criteria
-   d. If a component is shared and already partially implemented, extend rather than duplicate
-
-3. **Verify after each story** (build, lint, typecheck, test).
-
-4. **Commit after each story:** `feat(<feature-slug>): implement US-NNN -- <Story Title>`
-
-5. **Ask to continue** after each story.
-
-6. **When all stories are implemented:**
-   a. Detect design divergences using the same process described in "Design divergence detection" above. Report all divergences to the orchestrator with structured analysis of both resolution directions. Do NOT modify `design.adoc` directly.
-   b. Update `:last-updated:` in modified files
-   c. Commit any updates
-   d. Report to the orchestrator with the divergence report
-
-**Note:** No `tasks.adoc` is created in this flow. Progress is tracked via commits.
+No `tasks.adoc` is created. Progress tracked via commits.
 
 ## Reference
 
-See `references/example.adoc` for a walkthrough showing how a feature's Phase 1 tasks become implemented code.
+See `references/example.adoc` for a walkthrough.

--- a/skills/needs-security/SKILL.md
+++ b/skills/needs-security/SKILL.md
@@ -1,161 +1,68 @@
 ---
 name: needs-security
-description: Assess and remediate the project security posture. Use when the proven-needs orchestrator determines that security improvements are needed. Operates at the project level. Observes dependency vulnerabilities, code patterns (hardcoded secrets, injection risks, insecure defaults), and configuration issues. Proposes and applies remediations that satisfy security constraints.
+description: Assess and remediate the project security posture. Use when the proven-needs orchestrator determines that security improvements are needed. Operates at the project level. Observes dependency vulnerabilities, code patterns, and configuration issues. Proposes and applies remediations satisfying security constraints.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the desired state and current state context.
+Invoked by the `proven-needs` orchestrator with desired state and current state context.
 
 ## Observe
 
-Assess the current security posture of the project.
-
 ### 1. Dependency vulnerabilities
 
-Run the appropriate audit tool for the project's package manager:
-- `npm audit` / `yarn audit` / `pnpm audit`
-- `cargo audit`
-- `pip-audit`
-- `bundle-audit`
-
-Collect all known CVEs with severity levels (Critical, High, Medium, Low).
+Run the appropriate audit tool (`npm audit`, `cargo audit`, `pip-audit`, `bundle-audit`). Collect CVEs with severity levels.
 
 ### 2. Code pattern analysis
 
-Scan the codebase for common security anti-patterns:
-
 | Pattern | Risk | Detection |
 |---|---|---|
-| Hardcoded secrets | High | API keys, passwords, tokens in source files |
+| Hardcoded secrets | High | API keys, passwords, tokens in source |
 | SQL injection | High | String concatenation in queries |
-| Insecure deserialization | High | Unvalidated deserialization of external data |
-| Missing input validation | Medium | User inputs passed directly to business logic |
-| Insecure defaults | Medium | Default passwords, debug modes in production config |
+| Insecure deserialization | High | Unvalidated external data |
+| Missing input validation | Medium | User inputs passed directly to logic |
+| Insecure defaults | Medium | Default passwords, debug modes |
 | Missing authentication | Medium | Endpoints without auth checks |
 | Sensitive data in logs | Medium | PII or credentials logged |
-| Insecure crypto | Medium | Weak algorithms (MD5, SHA1 for security), small key sizes |
+| Insecure crypto | Medium | Weak algorithms (MD5/SHA1), small keys |
 
 ### 3. Configuration review
 
-Check for security-relevant configuration issues:
-- CORS settings
-- HTTPS enforcement
-- Cookie security flags (httpOnly, secure, sameSite)
-- Rate limiting configuration
-- Authentication/authorization configuration
+CORS settings, HTTPS enforcement, cookie security flags, rate limiting, auth configuration.
 
 ### 4. Read constraints
 
-Read `docs/constraints.adoc`. Identify all security constraints.
-
-### 5. Report observation
-
-Return to the orchestrator:
-```
-Security posture:
-  dependency-vulnerabilities: {critical: N, high: N, medium: N, low: N}
-  code-patterns: [{pattern, severity, file, line}]
-  configuration-issues: [{issue, severity}]
-  constraint-violations: [list]
-```
+Read `docs/constraints.adoc` for security constraints.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Map desired state to actions
-
 | Desired State | Actions |
 |---|---|
-| "No known vulnerabilities" | Patch dependencies (delegate to `needs-dependencies`), remediate code patterns |
-| "No hardcoded secrets" | Move secrets to environment variables or secret management |
-| "All user input validated" | Add validation layers where missing |
-| "Security best practices" | Address all findings by severity (Critical first) |
+| "No known vulnerabilities" | Patch deps (delegate to `needs-dependencies`), remediate code |
+| "No hardcoded secrets" | Move to env vars or secret management |
+| "All user input validated" | Add validation layers |
+| "Security best practices" | Address all findings by severity |
 
-### 2. Prioritize by severity
-
-1. Critical vulnerabilities and hardcoded secrets → immediate action
-2. High severity findings → action required
-3. Medium severity → recommended action
-4. Low severity → advisory
-
-### 3. Check constraint implications
-
-- Which constraint violations would be resolved?
-- Would any remediation introduce new issues (e.g., breaking API compatibility)?
-
-### 4. Report evaluation
-
-Return to the orchestrator:
-```
-Action: remediate / audit-only / none
-Findings by severity: {critical: N, high: N, medium: N, low: N}
-Proposed remediations: [{finding, remediation, risk, files-affected}]
-Dependency actions: [delegate to needs-dependencies]
-```
+Prioritize: Critical → High → Medium → Low.
 
 ## Execute
 
-```mermaid
-flowchart TD
-    OBS["Observe:<br/>vuln scan + code patterns<br/>+ config review"] --> PRIORITIZE["Prioritize<br/>by severity"]
-
-    PRIORITIZE --> CRIT["Critical<br/>→ immediate action"]
-    PRIORITIZE --> HI["High<br/>→ action required"]
-    PRIORITIZE --> MED["Medium<br/>→ recommended"]
-    PRIORITIZE --> LO["Low<br/>→ advisory"]
-
-    CRIT --> REMEDIATE
-    HI --> REMEDIATE
-    MED --> REMEDIATE
-
-    REMEDIATE{"Remediation<br/>type?"}
-    REMEDIATE -->|"Dependency<br/>vulnerability"| DEPS["Delegate to<br/>needs-dependencies"]
-    REMEDIATE -->|"Code<br/>anti-pattern"| CODE["Fix code<br/>(secrets, injection,<br/>validation, crypto)"]
-    REMEDIATE -->|"Configuration<br/>issue"| CONFIG["Apply secure<br/>configuration"]
-
-    DEPS --> VERIFY["Verify:<br/>re-scan + build + test"]
-    CODE --> VERIFY
-    CONFIG --> VERIFY
-
-    VERIFY -->|Pass| DONE["Report results"]
-    VERIFY -->|Fail| FIX["Fix issues"] --> VERIFY
-```
-
 ### 1. Dependency remediations
 
-For dependency vulnerabilities, delegate to the `needs-dependencies` capability via the orchestrator. This skill focuses on code and configuration remediations.
+Delegate to `needs-dependencies` via the orchestrator. This skill focuses on code and configuration.
 
 ### 2. Code remediations
 
-For each approved remediation:
-1. Apply the fix (move secrets, add validation, fix injection, etc.)
-2. Verify the fix doesn't break existing functionality
+Apply fixes (move secrets, add validation, fix injection, etc.). Verify no breakage.
 
 ### 3. Configuration remediations
 
-For each configuration issue:
-1. Apply the secure configuration
-2. Document the change
+Apply secure configuration. Document changes.
 
 ### 4. Verify
 
-After all remediations:
-1. Re-run security scans to confirm findings are resolved
-2. Run the build and test suite to confirm nothing is broken
-3. Verify all security constraints are satisfied
-
-### 5. Report results
-
-Return to the orchestrator:
-```
-Remediations applied: [{finding, fix, status}]
-Verification: {security-scan: pass/fail, build: pass/fail, tests: pass/fail}
-Constraint violations resolved: [list]
-Remaining findings: [list or none]
-```
+Re-run security scans, run build and test suite, verify all security constraints satisfied.
 
 ## Reference
 
-See `references/example.adoc` for an example showing a security assessment and remediation cycle.
+See `references/example.adoc` for an example.

--- a/skills/needs-spec/SKILL.md
+++ b/skills/needs-spec/SKILL.md
@@ -5,68 +5,20 @@ description: Create and maintain feature specifications with EARS requirements d
 
 ## Prerequisites
 
-Load the `ears-requirements` skill before writing requirements. It provides the EARS sentence types and templates.
+Load the `ears-requirements` skill before writing requirements.
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
 ## Observe
 
-Assess the current state of specifications for this feature.
-
-### 1. Read feature stories
-
-Read `docs/features/<slug>/user-stories.adoc`. Extract:
-- `:version:`
-- All stories with their acceptance criteria
-
-**If the file does not exist:** Report to the orchestrator that stories are missing. The orchestrator decides whether to create them first.
-
-### 2. Read existing spec
-
-If `docs/features/<slug>/spec.adoc` exists:
-- Read `:version:`, `:source-stories-version:`, `:last-updated:`
-- Extract all requirement IDs, texts, types, sources, and verifications
-- Count total requirements
-
-### 3. Read constraints
-
-Read `docs/constraints.adoc`. Identify constraints that overlap with this feature's domain -- these do not need to be duplicated as specs.
-
-### 4. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Stories: {exists: true, version: "X.Y.Z", count: N}
-Spec: {exists: true/false, version: "X.Y.Z", source-stories-version: "X.Y.Z", stale: true/false, count: N}
-Overlapping constraints: [list]
-```
+1. Read `docs/features/<slug>/user-stories.adoc`: extract `:version:` and all stories with acceptance criteria. If missing, report to orchestrator.
+2. If `docs/features/<slug>/spec.adoc` exists: read `:version:`, `:source-stories-version:`, all requirement IDs, texts, types, sources, and verifications.
+3. Read `docs/constraints.adoc` to identify constraints that overlap with this feature's domain (these should not be duplicated as specs).
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require spec changes?
-
-- If no spec exists → create spec
-- If spec exists but stories version differs → sync spec
-- If spec exists and versions match → check content alignment, report if current
-
-### 2. Check constraints
-
-- Requirements that duplicate a project-wide constraint should not appear in the feature spec
-- If an existing spec contains a requirement that has since been promoted to a constraint, flag it for removal
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / sync / none
-Requirements to add: N
-Requirements to modify: N
-Requirements to remove: N (including constraint overlaps)
-Constraint issues: [list or none]
-```
+1. No spec exists → create. Spec exists but stories version differs → sync. Versions match → check content alignment, report if current.
+2. Requirements duplicating a project-wide constraint should not appear in the spec. If a spec requirement has since been promoted to a constraint, flag it for removal.
 
 ## Execute
 
@@ -74,46 +26,22 @@ Constraint issues: [list or none]
 
 #### 1. Derive requirements
 
-For each acceptance criterion across all stories in this feature:
+For each acceptance criterion across all stories, translate into one or more black-box testable EARS requirements. Assign unique IDs: `<PREFIX>-<NNN>` where PREFIX is 2-5 uppercase characters from the feature slug (e.g., `product-browsing` → `PROD`, `shopping-cart` → `CART`). Present the proposed prefix to the user for confirmation.
 
-1. Translate it into one or more black-box testable EARS requirements
-2. Assign a unique ID: `<PREFIX>-<NNN>` where PREFIX is a 2-5 character uppercase prefix derived from the feature slug
+**Black-box litmus test:**
 
-**Prefix derivation:** Create a short, meaningful prefix from the feature slug:
-- `product-browsing` → `PROD`
-- `shopping-cart` → `CART`
-- `checkout` → `CHK`
-- `user-authentication` → `AUTH`
-- `password-reset-sms` → `PRS`
+> Could a tester who has never seen the source code verify this requirement using only the UI or public APIs? If not, rewrite it.
 
-Present the proposed prefix to the user for confirmation before proceeding.
+Requirements must NOT reference internal architecture, database schemas, API paths, languages/frameworks, internal data structures, or file system paths.
 
-**Black-box testing constraint -- the litmus test:**
+Requirements MUST describe what the user observes, what inputs produce what outputs, observable state transitions, timing from the user's perspective, and error feedback.
 
-> Could a tester who has never seen the source code verify this requirement using only the system's user interface or public APIs? If not, rewrite it.
-
-Requirements must NOT reference:
-- Internal architecture, components, or modules
-- Database schemas, tables, or queries
-- API endpoint paths or HTTP methods
-- Programming languages, frameworks, or libraries
-- Internal data structures or algorithms
-- File system paths or internal configuration
-
-Requirements MUST describe:
-- What the user or external actor observes
-- What inputs produce what outputs
-- Observable system states and transitions
-- Timing and performance from the user's perspective
-- Error messages and feedback presented to the user
-
-**Constraint filtering:** If a derived requirement is already covered by a constraint in `docs/constraints.adoc`, do not include it in the spec. Instead, note in the spec that the constraint applies:
-
+**Constraint filtering:** If a requirement is already covered by `docs/constraints.adoc`, don't include it. Add a NOTE instead:
 ```asciidoc
-NOTE: Password strength requirements are enforced by project constraint (Security: "Passwords must be at least 8 characters with mixed case and numbers"). Not duplicated here.
+NOTE: Password strength requirements are enforced by project constraint (Security). Not duplicated here.
 ```
 
-**Multi-source requirements:** A single requirement may be derived from criteria across multiple stories within this feature. Use comma-separated sources: `Source:: US-001: Criterion 3, US-002: Criterion 1`.
+**Multi-source requirements:** Use comma-separated sources: `Source:: US-001: Criterion 3, US-002: Criterion 1`.
 
 #### 2. Write the spec file
 
@@ -133,100 +61,48 @@ The system shall display products in a grid or list format.
 
 Type:: Ubiquitous
 Source:: US-001: View Product Catalog, Criterion 1
-Verification:: Open the product catalog page. Confirm that products are displayed in a grid or list layout.
+Verification:: Open the product catalog page. Confirm products display in grid or list layout.
 
 == <PREFIX>-002
 When the user selects a category filter, the system shall display only products in that category.
 
 Type:: Event-driven
 Source:: US-001: View Product Catalog, Criterion 3
-Verification:: Select a category filter. Confirm that only products in the selected category are displayed.
+Verification:: Select a category filter. Confirm only matching products display.
 
 == Traceability
 
 [cols="1,2,2", options="header"]
 |===
 | Requirement ID | Requirement Summary | Source
-
-| <PREFIX>-001
-| Product display format
-| US-001: Criterion 1
-
-| <PREFIX>-002
-| Category filtering
-| US-001: Criterion 3
+| <PREFIX>-001 | Product display format | US-001: Criterion 1
+| <PREFIX>-002 | Category filtering | US-001: Criterion 3
 |===
 ```
 
-Each requirement includes:
-- The EARS requirement text as the section content
-- `Type` -- the EARS sentence type used
-- `Source` -- traceability to user story and criterion within this feature
-- `Verification` -- a brief black-box test description
-
 ### Syncing an existing spec
-
-```mermaid
-flowchart TD
-    START["Sync triggered"] --> STALE{"Quick staleness check:<br/>source-stories-version<br/>≠ stories version?"}
-
-    STALE -->|No| CURRENT["Spec appears current<br/>→ report to orchestrator"]
-    STALE -->|Yes| ANALYZE["Content-based<br/>change analysis"]
-
-    ANALYZE --> NEW["New criteria<br/>→ derive new reqs"]
-    ANALYZE --> MOD["Modified criteria<br/>→ update affected reqs"]
-    ANALYZE --> UNCH["Unchanged criteria<br/>→ no action"]
-    ANALYZE --> ORPH["Orphaned reqs<br/>(source removed)<br/>→ mark for removal"]
-    ANALYZE --> PROM["Promoted to constraint<br/>→ mark for removal"]
-
-    NEW --> REPORT["Present change report<br/>to user"]
-    MOD --> REPORT
-    ORPH --> REPORT
-    PROM --> REPORT
-
-    REPORT --> CONFIRM{"User<br/>confirms?"}
-    CONFIRM -->|Yes| APPLY["Apply changes"]
-    CONFIRM -->|Adjust| REPORT
-
-    APPLY --> BUMP["Version bump<br/>+ update source-stories-version"]
-```
 
 #### 1. Quick staleness check
 
-Compare `:source-stories-version:` in `spec.adoc` against `:version:` in `user-stories.adoc`. If versions match, inform the orchestrator that the spec appears current. The orchestrator decides whether to force re-analysis.
+Compare `:source-stories-version:` against stories `:version:`. If they match, report current to orchestrator.
 
 #### 2. Content-based change analysis
 
-1. Read all current stories and their acceptance criteria
-2. Read all existing requirements and their `Source` traceability links
-3. For each story criterion, determine:
-   - **New** -- no corresponding requirement exists → derive new requirements
-   - **Modified** -- the source criterion wording or intent changed → update affected requirements
-   - **Unchanged** -- criterion and corresponding requirement still align → no action
-4. For each existing requirement, check if its source criterion still exists:
-   - **Orphaned** -- source criterion was removed → mark for removal
-5. Check for requirements that now overlap with constraints added since last sync:
-   - **Promoted to constraint** -- requirement is now covered by `docs/constraints.adoc` → mark for removal
+For each story criterion determine: **New** (no requirement exists), **Modified** (wording/intent changed), **Unchanged**. For each existing requirement check: **Orphaned** (source removed), **Promoted to constraint** (now in `docs/constraints.adoc`).
 
 #### 3. Present change report
 
 ```
 Spec sync: stories 1.0.0 -> 1.1.0
 
-Added:
-  - PROD-005: [new requirement summary]
-
-Modified:
-  - PROD-002: [old text] -> [new text]
-
-Removed:
-  - PROD-004: [reason - source US-003 removed]
-  - PROD-006: [promoted to project constraint]
-
-No changes to: PROD-001, PROD-003
+Added:   PROD-005: [summary]
+Modified: PROD-002: [old] -> [new]
+Removed:  PROD-004: source US-003 removed
+          PROD-006: promoted to project constraint
+No changes: PROD-001, PROD-003
 ```
 
-Ask the user to confirm before applying changes.
+Ask user to confirm before applying.
 
 #### 4. Apply changes and bump versions
 
@@ -234,27 +110,20 @@ Ask the user to confirm before applying changes.
 |---|---|
 | Requirements removed | MAJOR |
 | Requirements added or modified | MINOR |
-| Traceability or metadata updates only | PATCH |
+| Traceability or metadata only | PATCH |
 
-- Update `:source-stories-version:` to match current stories version
-- Update `:version:` according to bump rules
-- Update `:last-updated:` to today's date
-- Update the traceability section
+Update `:source-stories-version:`, `:version:`, `:last-updated:`, and traceability section.
 
 ## Quality Checklist
 
-Before finalizing, verify every item:
 - Every requirement uses the correct EARS sentence type
 - Every requirement passes the black-box litmus test
 - Every requirement has a unique ID with the feature prefix
-- Every requirement traces back to at least one story criterion within this feature
-- Multi-source requirements list all sources
-- No duplicate or conflicting requirements
-- No requirements that duplicate project-wide constraints
-- The traceability section is complete
-- Version numbers are correct and updated
-- `:source-stories-version:` matches the stories `:version:`
+- Every requirement traces back to at least one story criterion
+- No duplicates, conflicts, or constraint overlaps
+- Traceability section is complete
+- Version numbers correct and `:source-stories-version:` matches stories
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing how feature stories become a feature specification.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-stories/SKILL.md
+++ b/skills/needs-stories/SKILL.md
@@ -5,64 +5,20 @@ description: Create and update user stories with EARS acceptance criteria for a 
 
 ## Prerequisites
 
-Load the `ears-requirements` skill before writing acceptance criteria. It provides the EARS sentence types and templates.
+Load the `ears-requirements` skill before writing acceptance criteria.
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
 ## Observe
 
-Assess the current state of user stories for this feature.
-
-### 1. Check feature directory
-
-Look for `docs/features/<slug>/`. If the directory does not exist, note that this is a new feature -- no stories exist yet.
-
-### 2. Read existing stories
-
-If `docs/features/<slug>/user-stories.adoc` exists:
-- Read `:version:` and `:last-updated:`
-- Extract all story IDs, titles, and acceptance criteria
-- Count total stories
-
-### 3. Read constraints
-
-Read `docs/constraints.adoc`. Identify any constraints relevant to story quality (e.g., quality constraints about testability, completeness).
-
-### 4. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Stories: {exists: true/false, version: "X.Y.Z", count: N, story_ids: [...]}
-```
+1. Check if `docs/features/<slug>/` exists. If not, this is a new feature.
+2. If `user-stories.adoc` exists: read `:version:`, `:last-updated:`, all story IDs, titles, and acceptance criteria.
+3. Read `docs/constraints.adoc` for quality constraints (testability, completeness).
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require new stories?
-
-- If no stories exist and the intent requires them → create stories
-- If stories exist but the intent adds new functionality → add stories
-- If stories exist but the intent modifies existing behavior → modify stories
-- If stories exist and fully cover the desired state → no action needed
-
-### 2. Check constraints
-
-Verify that proposed stories would not violate any constraints:
-- Stories must be testable (quality constraint)
-- Stories must not duplicate constraint-level requirements (cross-cutting requirements belong in `docs/constraints.adoc`, not stories)
-- Each story must be scoped to this one feature (must not require knowledge of other features)
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / add / modify / none
-Stories to create: N
-Stories to modify: [list]
-Constraint issues: [list or none]
-```
+1. No stories exist and intent requires them → create. Stories exist but intent adds new functionality → add. Intent modifies existing behavior → modify. Stories fully cover the desired state → no action.
+2. Verify proposed stories: must be testable, must not duplicate constraint-level requirements, must be scoped to this one feature.
 
 ## Execute
 
@@ -70,23 +26,13 @@ Constraint issues: [list or none]
 
 #### 1. Analyze the intent
 
-Read the intent (desired state) provided by the orchestrator. Identify:
-- The main functionality requested
-- Who the users are (roles)
-- What problems they want solved
-- Any specific requirements mentioned
+Identify: main functionality, user roles, problems to solve, specific requirements mentioned.
 
 #### 2. Decompose into stories
 
-Break functionality into atomic user stories. Each story must:
-- Be implementable in 1-3 days
-- Deliver clear user value
-- Have testable acceptance criteria
-- Be scoped entirely within this feature (no cross-feature dependencies)
+Each story must: be implementable in 1-3 days, deliver clear user value, have testable acceptance criteria, be scoped entirely within this feature. If a story seems too broad, split it or flag it for feature decomposition.
 
-A story must not be phrased so broadly that it spans multiple features. If a story seems too broad, split it or flag it to the orchestrator for potential feature decomposition.
-
-Common decomposition patterns:
+Common patterns:
 
 | Feature Type | Typical Stories |
 |---|---|
@@ -97,27 +43,18 @@ Common decomposition patterns:
 
 #### 3. Write each story
 
-For each story provide:
-
-**Title:** Concise, descriptive (e.g., "User Registration")
-
 **User story statement:**
-
 ```
 As a [specific user role],
 I want [specific action/feature],
 so that [benefit/value].
 ```
 
-**Acceptance criteria:** Write each criterion using the appropriate EARS sentence type from the `ears-requirements` skill. Each criterion must be specific, unambiguous, and verifiable. Cover happy path, edge cases, and error scenarios.
+**Acceptance criteria:** Use the appropriate EARS sentence type from `ears-requirements`. Each criterion must be specific, unambiguous, and verifiable. Cover happy path, edge cases, and error scenarios.
 
 #### 4. Check for constraint-level requirements
 
-While writing acceptance criteria, check each criterion:
-- Does this criterion apply only to this feature? → Keep as acceptance criterion
-- Would this criterion apply to other features too? → Flag to the orchestrator as a potential constraint
-
-Example: "The system shall enforce minimum password security requirements" applies to registration, password reset, and any future password feature → flag as potential constraint.
+For each criterion: if it applies only to this feature → keep as criterion. If it would apply to other features too → flag to the orchestrator as a potential constraint.
 
 #### 5. Write the file
 
@@ -145,51 +82,40 @@ Acceptance Criteria:
 ...
 ```
 
-Story IDs are sequential within this feature file (US-001, US-002, ...). IDs are unique within the feature, not globally.
+Story IDs are sequential within this feature (US-001, US-002, ...), unique within the feature only.
 
 ### Adding stories to an existing feature
 
-1. Read the existing stories and the next available US-NNN ID.
-2. Before adding, check for stories with substantially similar scope. If a potential duplicate is found, present both to the user and ask whether to merge, replace, or keep both.
-3. Assign the next sequential `US-NNN` ID after the highest existing ID.
-4. Bump the version: MINOR (new content added).
-5. Update `:last-updated:` to today's date.
+1. Read existing stories and next available US-NNN ID.
+2. Check for substantially similar scope. If duplicate found, present both and ask whether to merge, replace, or keep both.
+3. Assign next sequential ID. MINOR version bump. Update `:last-updated:`.
 
 ### Modifying existing stories
 
-1. Identify which stories the user wants to modify.
-2. Present the proposed changes: show the current text alongside the new text.
-3. Ask the user to confirm before applying.
-4. Bump the version:
-   - Acceptance criteria fundamentally rewritten: MAJOR
-   - Criteria refined or adjusted (non-breaking): MINOR
-   - Typos, formatting, clarifications: PATCH
-5. Update `:last-updated:` to today's date.
+1. Present proposed changes: current text alongside new text.
+2. Ask user to confirm.
+3. Version bump: MAJOR (fundamentally rewritten), MINOR (refined/adjusted), PATCH (typos/formatting).
 
 ### Removing stories
 
-1. Identify the stories to remove.
-2. **Warn about downstream impact:** Removing stories may make the feature's spec and design stale. Inform the user.
-3. Ask the user to confirm.
-4. Remove the stories. Do not renumber remaining stories (IDs are stable).
-5. Bump the version: MAJOR (content removed).
-6. Update `:last-updated:` to today's date.
+1. Warn about downstream impact (spec and design may become stale).
+2. Ask user to confirm. Remove stories. Do NOT renumber remaining stories (IDs are stable).
+3. MAJOR version bump.
 
 ## Quality Checklist (INVEST)
 
-Before finalizing, verify:
 - Each story has clear user value
 - Acceptance criteria use the correct EARS sentence type
-- Acceptance criteria are specific, unambiguous, and verifiable
+- Criteria are specific, unambiguous, and verifiable
 - Stories are independent and can be implemented in any order
-- No story is too large (break down if needed)
-- Error and edge case scenarios are covered using the "If ... then" (unwanted behavior) EARS type
+- No story is too large
+- Error and edge cases covered using "If ... then" EARS type
 - No story spans multiple features
-- Cross-cutting requirements have been flagged as potential constraints
-- Version and date are updated
+- Cross-cutting requirements flagged as potential constraints
+- Version and date updated
 
-INVEST criteria: **I**ndependent, **N**egotiable, **V**aluable, **E**stimable, **S**mall, **T**estable.
+INVEST: **I**ndependent, **N**egotiable, **V**aluable, **E**stimable, **S**mall, **T**estable.
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing how a feature intent becomes structured user stories within a feature package.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-tasks/SKILL.md
+++ b/skills/needs-tasks/SKILL.md
@@ -1,147 +1,68 @@
 ---
 name: needs-tasks
-description: Create phased implementation task lists for a feature. Use when the proven-needs orchestrator determines that a feature needs a task breakdown. Operates within a single feature package at docs/features/<slug>/. Tasks define the WORK — discrete coding units organized into sequential phases with parallelism markers and full traceability back to the feature's specs and stories.
+description: Create phased implementation task lists for a feature. Use when the proven-needs orchestrator determines that a feature needs a task breakdown. Operates within a single feature package at docs/features/<slug>/. Tasks define WORK — discrete coding units organized into sequential phases with parallelism markers and traceability.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
 ## Observe
 
-Assess the current state of the task list for this feature.
-
-### 1. Read feature design
-
-Read `docs/features/<slug>/design.adoc`. Extract `:version:`, `:status:`, system design sections, story resolution mappings. Also read `data-model.adoc` and `contracts/` if they exist within the feature package.
-
-**If missing:** Note that design is unavailable. Report to the orchestrator. Tasks will be derived directly from user stories (story-driven derivation). If proceeding: set `:source-design-version:` to `n/a`.
-
-### 2. Read feature stories and spec
-
-- **`docs/features/<slug>/user-stories.adoc`** -- extract story IDs, titles, acceptance criteria, and `:version:`.
-- **`docs/features/<slug>/spec.adoc`** -- extract spec IDs and `:version:`. If missing, set `:source-spec-version:` to `n/a`.
-
-### 3. Read existing task list
-
-If `docs/features/<slug>/tasks.adoc` exists:
-- Read `:version:`, `:status:`, `:source-design-version:`, `:source-stories-version:`, `:source-spec-version:`
-- Read all phases, tasks, tick states, and metadata
-
-### 4. Read constraints
-
-Read `docs/constraints.adoc`. Identify quality constraints relevant to task planning.
-
-### 5. Analyze codebase
-
-If this is not a greenfield project, analyze what already exists to avoid creating tasks for things already implemented.
-
-### 6. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Design: {exists: true/false, version: "X.Y.Z", status: "Current/Stale"}
-Stories: {exists: true, version: "X.Y.Z"}
-Spec: {exists: true/false, version: "X.Y.Z"}
-Tasks: {exists: true/false, version: "X.Y.Z", status: "Current/Stale/Implemented", progress: "N/M ticked"}
-```
+1. Read `docs/features/<slug>/design.adoc`: extract `:version:`, `:status:`, system design, story resolution. Also read `data-model.adoc` and `contracts/` if present. If missing, tasks will derive from stories directly (set `:source-design-version: n/a`).
+2. Read `user-stories.adoc` (story IDs, titles, criteria, `:version:`) and `spec.adoc` (spec IDs, `:version:`). If spec missing, set `:source-spec-version: n/a`.
+3. If `tasks.adoc` exists: read `:version:`, `:status:`, source versions, phases, tasks, tick states.
+4. Read `docs/constraints.adoc` for quality constraints relevant to task planning.
+5. Analyze codebase to avoid creating tasks for things already implemented.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require task changes?
-
 | Condition | Action |
 |---|---|
-| No task list exists | Create task list |
-| Task list exists, `:status:` is `Implemented` | Previous cycle complete. Create fresh task list (overwrite). |
-| Source versions match, no tasks ticked | Task list appears current. Report to orchestrator. |
-| Source versions match, some tasks ticked | Partial progress. Report to orchestrator. |
-| `:source-design-version:` differs from current design | Task list is stale. Determine whether to recreate or incrementally update. |
+| No task list exists | Create |
+| `:status: Implemented` | Fresh task list (overwrite) |
+| Source versions match, no tasks ticked | Current, report to orchestrator |
+| Source versions match, some ticked | Partial progress, report |
+| `:source-design-version:` differs | Stale -- recommend updating design first (staleness flows through design) |
 
-### 2. Transitive staleness check
-
-If `:source-design-version:` matches the current design version, trust that the design is current -- the design skill is responsible for tracking its own upstream staleness against stories and specs.
-
-If `:source-design-version:` does not match, the task list is stale. Warn the orchestrator and recommend updating the design first (which will cascade any upstream story/spec changes into the design before tasks are regenerated).
-
-Do not independently compare `:source-stories-version:` or `:source-spec-version:` against their current versions. Those are recorded for traceability, but staleness detection flows through the design.
-
-### 3. Check constraints
-
-Verify that task organization respects quality constraints (e.g., test coverage must not decrease -- ensure testing tasks exist).
-
-### 4. Report evaluation
-
-Return to the orchestrator:
-```
-Action: create / update / none
-Staleness: {design: true/false, transitive: true/false}
-Constraint issues: [list or none]
-```
+Do not independently compare `:source-stories-version:` or `:source-spec-version:` -- those are for traceability. Staleness detection flows through the design.
 
 ## Execute
 
 ### Design-driven task decomposition (default)
 
-When a design document exists, walk through it systematically to identify discrete implementation units. Each task should be a single coding unit -- small enough to implement in one sitting.
-
-**Sources of tasks:**
+Walk through the design systematically. Each task is a single coding unit.
 
 | Design Section | Task Types |
 |---|---|
-| Data model entities | Entity/model creation, migrations, validation rules |
-| System design components | Module/service setup, core logic implementation |
-| Interface contracts / API endpoints | Endpoint implementation, request/response handling |
-| Frontend components | Component creation, state management wiring |
-| External integrations | Service client setup, integration logic |
-| Story resolution -- error cases | Error handling, edge cases |
-| Story resolution -- notifications | Notification/email implementation |
+| Data model entities | Entity creation, migrations, validation |
+| System design components | Module/service setup, core logic |
+| Interface contracts / APIs | Endpoint implementation, request/response |
+| Frontend components | Component creation, state wiring |
+| External integrations | Service clients, integration logic |
+| Story resolution -- errors | Error handling, edge cases |
 
-**For each task, record:**
-- A clear, actionable title
-- Which design components are involved
-- Which spec IDs it satisfies (when spec exists)
-- Which user stories it contributes to
-- Whether it depends on other tasks (determines phase placement and parallelism)
+For each task record: title, design components involved, spec IDs satisfied, user stories contributed to, dependencies (determines phase/parallelism).
 
-### Story-driven task derivation (when no design exists)
+### Story-driven task derivation (no design)
 
-When `:source-design-version:` is `n/a`, derive tasks directly from user stories:
-
-1. Read each story and its acceptance criteria
-2. For each story, create one or more tasks. Group related criteria into a single task when tightly coupled; split when independently implementable.
-3. For each task, record:
-   - A clear, actionable title
-   - Which user stories it implements
-   - Which spec IDs it satisfies (when spec exists; omit `Specs::` if also `n/a`)
-   - `Components::` is omitted since there is no design to reference
-4. Use story groupings to inform phase organization
+Derive tasks from stories and acceptance criteria. Group related criteria into a single task when tightly coupled; split when independently implementable. Omit `Components::` field. Use story groupings to inform phase organization.
 
 ### Organize into phases
 
-Group tasks into sequential phases based on implementation dependencies.
-
-**Typical phase progression** (adapt to the project):
+Group tasks by implementation dependencies:
 
 | Phase | Purpose | Examples |
 |---|---|---|
-| Foundation | Infrastructure, data model, configuration | Database setup, entity creation, project scaffolding |
-| Core Logic | Business logic, services, core modules | Service implementations, domain logic |
-| Interface Layer | APIs, UI components, CLI commands | Endpoint handlers, React components, command parsers |
-| Integration | External services, cross-cutting concerns | Payment providers, email services, auth |
-| Polish | Error handling, edge cases, notifications | Error responses, validation messages, notification triggers |
+| Foundation | Infrastructure, data model, config | DB setup, entity creation, scaffolding |
+| Core Logic | Business logic, services | Service implementations, domain logic |
+| Interface Layer | APIs, UI, CLI | Endpoints, React components, parsers |
+| Integration | External services, cross-cutting | Payment, email, auth |
+| Polish | Error handling, edge cases | Error responses, validation messages |
 
-Within each phase, mark every task:
-- **`[parallel]`** -- can be implemented concurrently. No dependency on other tasks within the phase.
-- **`[sequential]`** -- must be completed before subsequent sequential tasks in the same phase.
+Within each phase mark tasks: **`[parallel]`** (no intra-phase dependencies) or **`[sequential]`** (must precede subsequent sequential tasks).
 
-**Guidelines:**
-- A task belongs in the earliest phase where all its dependencies are satisfied
-- Prefer more parallel tasks over fewer sequential ones
-- If a phase would contain only one task, consider merging with an adjacent phase
+Guidelines: earliest phase where dependencies are satisfied, prefer parallel over sequential, merge single-task phases with adjacent ones.
 
 ### Write task list
 
@@ -159,73 +80,48 @@ Create `docs/features/<slug>/tasks.adoc`:
 :toc:
 
 == Overview
-
-<Brief summary: what is being implemented, number of phases, total tasks.>
+<Summary: what is being implemented, phases, total tasks.>
 
 == Phase 1: <Phase Name>
+<One-sentence purpose.>
 
-<One-sentence phase purpose.>
-
-* [ ] TASK-001: <Task title> [parallel]
+* [ ] TASK-001: <Title> [parallel]
 +
-Components:: <design components involved>
+Components:: <design components>
 Stories:: <story numbers>
 Specs:: <spec IDs>
-Description:: <What to implement and key details>
-
-* [ ] TASK-002: <Task title> [sequential]
-+
-Components:: <design components involved>
-Stories:: <story numbers>
-Specs:: <spec IDs>
-Description:: <What to implement and key details>
+Description:: <What to implement>
 
 == Phase 2: <Phase Name>
-
 ...
 
 == Traceability
-
 [cols="1,1,1", options="header"]
 |===
 | Story | Spec IDs | Tasks
-
 | US-001: <title> | PROD-001, PROD-002 | TASK-001, TASK-005
-| US-002: <title> | PROD-005, PROD-006 | TASK-002, TASK-006
 |===
 ```
 
-**`:status:` values:**
-- `Current` -- task list is valid and aligned with design
-- `Stale` -- design has changed since this task list was created
-- `Implemented` -- all tasks are ticked off
+**`:status:` values:** `Current`, `Stale`, `Implemented` (all ticked).
 
-**Version rules:**
-- `:version:` uses SemVer, starts at `1.0.0`
-- `:source-design-version:` records which design version was used; `n/a` if design was skipped
-- `:source-stories-version:` and `:source-spec-version:` record upstream versions; `n/a` if skipped
-- `:last-updated:` set to today's date
+**Task IDs:** Sequential (TASK-001, TASK-002, ...). Stable -- do not renumber.
 
-**Task IDs:** Sequential within the document: TASK-001, TASK-002, etc. IDs are stable -- do not renumber when updating.
+**Ticking:** `[ ]` → `[x]` on completion. All ticked → `:status: Implemented`.
 
-**Ticking off tasks:** When a task is completed, change `[ ]` to `[x]`. When all tasks are ticked, set `:status:` to `Implemented`.
-
-**Task file lifecycle:** Tasks guide implementation but are not the source of truth for feature completion -- spec-derived tests serve that role. Once a feature reaches `Implemented` (all spec-derived tests pass), the task file may be removed at the team's discretion.
+**Lifecycle:** Tasks guide implementation but are not the source of truth for completion -- spec-derived tests serve that role. May be removed after reaching `Implemented`.
 
 ## Quality Checklist
 
-Before finalizing, verify:
-- Every spec ID from the feature's `spec.adoc` appears in at least one task (skip if `:source-spec-version:` is `n/a`)
-- Every user story is covered by the aggregate tasks
-- Every design section has corresponding tasks (skip if `:source-design-version:` is `n/a`)
-- No circular dependencies between phases
-- Phase ordering respects actual implementation dependencies
-- Each task is a discrete, implementable coding unit
-- Parallel/sequential markers are correct
-- The traceability section is complete and accurate
-- Source versions are recorded correctly
-- Quality constraints from `docs/constraints.adoc` are addressed (e.g., testing tasks exist if coverage constraints apply)
+- Every spec ID appears in at least one task (skip if `:source-spec-version: n/a`)
+- Every user story covered
+- Every design section has tasks (skip if `:source-design-version: n/a`)
+- No circular phase dependencies
+- Each task is a discrete coding unit
+- Parallel/sequential markers correct
+- Traceability complete
+- Source versions recorded
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing how a feature design becomes a phased task list with traceability.
+See `references/example.adoc` for a complete example.

--- a/skills/needs-tests/SKILL.md
+++ b/skills/needs-tests/SKILL.md
@@ -1,238 +1,105 @@
 ---
 name: needs-tests
-description: Derive and generate tests from feature specifications. Use when the proven-needs orchestrator determines that a feature needs test coverage. Operates within a single feature package at docs/features/<slug>/. Translates the black-box verification descriptions in spec.adoc into executable test cases, using the project's existing test framework and conventions.
+description: Derive and generate tests from feature specifications. Use when the proven-needs orchestrator determines that a feature needs test coverage. Operates within a single feature package at docs/features/<slug>/. Translates black-box verification descriptions in spec.adoc into executable test cases using the project's test framework.
 ---
 
 ## Prerequisites
 
-This skill is invoked by the `proven-needs` orchestrator, which provides the feature context (slug, intent, current state).
+Invoked by the `proven-needs` orchestrator with feature context (slug, intent, current state).
 
 ## Observe
 
-Assess the current state of tests for this feature.
-
-### 1. Read feature spec
-
-Read `docs/features/<slug>/spec.adoc`. Extract all requirement IDs, EARS requirement texts, types, and verification descriptions.
-
-**If missing:** Report to the orchestrator that specs are missing. Tests cannot be derived without specifications -- the verification descriptions in the spec are the primary source for test cases.
-
-### 2. Read feature design
-
-Read `docs/features/<slug>/design.adoc`. Extract system design sections, interface contracts, and data model information. These inform test setup, fixtures, and integration points.
-
-**If missing:** Note that tests will be limited to black-box behavioral tests without internal structure guidance.
-
-### 3. Read feature stories
-
-Read `docs/features/<slug>/user-stories.adoc` for context on acceptance criteria and user journeys. Stories provide the narrative context that helps write meaningful test descriptions.
-
-### 4. Read existing tests
-
-Scan the project's test directories for existing test files related to this feature:
-- Match by feature slug in file/directory names
-- Match by spec ID references in test descriptions
-- Check for existing test infrastructure (helpers, fixtures, factories)
-
-### 5. Read constraints
-
-Read `docs/constraints.adoc`. Identify quality constraints relevant to testing (coverage thresholds, test requirements).
-
-### 6. Analyze test infrastructure
-
-Detect the project's test framework and conventions:
-- **JavaScript/TypeScript:** Jest, Vitest, Mocha, Playwright, Cypress
-- **Rust:** built-in test framework, integration test conventions
-- **Go:** testing package, testify
-- **Python:** pytest, unittest
-- **Ruby:** RSpec, Minitest
-
-Note: test file locations, naming conventions, assertion style, existing fixtures/helpers.
-
-### 7. Report observation
-
-Return to the orchestrator:
-```
-Feature: <slug>
-Spec: {exists: true, version: "X.Y.Z", requirement-count: N}
-Design: {exists: true/false}
-Existing tests: {count: N, spec-ids-covered: [...], spec-ids-missing: [...]}
-Test framework: <framework>
-Coverage constraints: [list or none]
-```
+1. Read `docs/features/<slug>/spec.adoc`: all requirement IDs, EARS texts, types, verification descriptions. If missing, report to orchestrator -- tests cannot be derived without specs.
+2. Read `docs/features/<slug>/design.adoc` for component structure, interfaces, data model (informs test setup and level). If missing, tests will be limited to black-box behavioral tests.
+3. Read `docs/features/<slug>/user-stories.adoc` for narrative context.
+4. Scan test directories for existing tests (match by slug or spec ID references). Note existing infrastructure (helpers, fixtures, factories).
+5. Read `docs/constraints.adoc` for quality constraints (coverage thresholds, test requirements).
+6. Detect test framework: Jest/Vitest/Mocha/Playwright/Cypress (JS/TS), built-in (Rust), testing/testify (Go), pytest/unittest (Python), RSpec/Minitest (Ruby). Note file locations, naming conventions, assertion style.
 
 ## Evaluate
 
-Given the desired state from the orchestrator, determine what action is needed.
-
-### 1. Does the desired state require test changes?
-
 | Condition | Action |
 |---|---|
-| No tests exist for this feature | Generate full test suite |
-| Tests exist but spec has been updated (new/modified requirements) | Generate tests for new requirements, update tests for modified requirements |
-| Tests exist and cover all current spec IDs | Tests appear current. Report to orchestrator. |
-| Tests exist but some spec IDs are not covered | Generate tests for uncovered requirements |
-
-### 2. Check constraints
-
-- Quality constraints: coverage thresholds that must be met
-- Are there requirements for specific test types (unit, integration, e2e)?
-
-### 3. Report evaluation
-
-Return to the orchestrator:
-```
-Action: generate / update / none
-Requirements to test: N (new: N, modified: N, uncovered: N)
-Constraint requirements: [coverage threshold, test type requirements]
-```
+| No tests for this feature | Generate full test suite |
+| Tests exist, spec updated | Generate for new reqs, update for modified |
+| Tests exist, all spec IDs covered | Current, report to orchestrator |
+| Tests exist, some spec IDs missing | Generate for uncovered requirements |
 
 ## Execute
 
-```mermaid
-flowchart TD
-    SPEC["spec.adoc<br/>requirements"] --> TYPE{"EARS<br/>type?"}
-
-    TYPE -->|Ubiquitous| T1["Unconditional assertions<br/>(test across states,<br/>on load, after nav)"]
-    TYPE -->|Event-driven| T2["Trigger event → assert response<br/>(valid + invalid triggers)"]
-    TYPE -->|State-driven| T3["Enter state → assert behavior<br/>(test entry/exit boundaries)"]
-    TYPE -->|Unwanted| T4["Trigger error → assert<br/>recovery/handling"]
-    TYPE -->|Optional| T5["Enable → assert present<br/>Disable → assert absent"]
-
-    T1 --> LEVEL
-    T2 --> LEVEL
-    T3 --> LEVEL
-    T4 --> LEVEL
-    T5 --> LEVEL
-
-    LEVEL{"Test level<br/>(from design)"}
-    LEVEL -->|"Single component,<br/>clear I/O"| UNIT["Unit test"]
-    LEVEL -->|"Multiple components<br/>or persistence"| INTEG["Integration test"]
-    LEVEL -->|"Full user journey<br/>or UI interaction"| E2E["End-to-end test"]
-```
-
 ### Derive test cases from specifications
 
-**Every requirement in `spec.adoc` MUST have at least one test.** A requirement without a corresponding test is not verified and blocks the feature from reaching `Implemented`. There are no exceptions -- if a requirement exists in the spec, it gets a test.
+**Every requirement in `spec.adoc` MUST have at least one test. No exceptions.** A requirement without a test blocks the feature from `Implemented`.
 
-For each requirement in `spec.adoc`:
+For each requirement:
 
 #### 1. Analyze the requirement
 
-Read the EARS requirement text, type, and verification description. The verification field describes the black-box test scenario in plain language -- this is the primary source for the test case.
-
 | EARS Type | Test Pattern |
 |---|---|
-| Ubiquitous | Assert the behavior holds unconditionally. Test on page load, after navigation, across states. |
-| Event-driven | Trigger the event, assert the response. Test with valid and invalid triggers. |
-| State-driven | Enter the state, assert the behavior. Test state entry and exit boundaries. |
-| Unwanted behavior | Trigger the error condition, assert the recovery/handling response. |
-| Optional feature | Enable the feature, assert behavior. Disable, assert absence. |
+| Ubiquitous | Assert behavior holds unconditionally (on load, after nav, across states) |
+| Event-driven | Trigger event → assert response (valid + invalid triggers) |
+| State-driven | Enter state → assert behavior (test entry/exit boundaries) |
+| Unwanted behavior | Trigger error → assert recovery/handling |
+| Optional feature | Enable → assert present; disable → assert absent |
 
 #### 2. Determine test level
 
-Based on the requirement and available design information:
-
-| Test Level | When to Use |
+| Level | When |
 |---|---|
-| **Unit test** | Requirement maps to a single component with clear inputs/outputs (from design) |
-| **Integration test** | Requirement spans multiple components or involves data persistence |
-| **End-to-end test** | Requirement describes a full user journey or UI interaction |
+| Unit | Single component with clear I/O (from design) |
+| Integration | Multiple components or persistence |
+| End-to-end | Full user journey or UI interaction |
 
-When the design is available, use the Story Resolution section to identify which components are involved -- this informs the test level. When no design is available, default to integration or e2e tests (black-box by nature).
+Use design's Story Resolution to identify components. Without design, default to integration/e2e.
 
 #### 3. Write the test case
 
-Each test case must:
-- Reference the spec ID in the test description (e.g., `"PROD-001: displays products in grid or list format"`)
-- Follow the project's existing test conventions (file naming, assertion style, setup/teardown patterns)
-- Include the happy path from the verification description
-- Include at least one edge case or error scenario derived from the EARS type
-- Use existing test infrastructure (factories, fixtures, helpers) where available
+Each test must: reference spec ID in description, follow project conventions, include happy path from verification field, include at least one edge case derived from EARS type, use existing infrastructure.
 
 ### Organize test files
 
-Follow the project's existing test file organization. If no convention exists, use:
-
+Follow project conventions. Default:
 ```
-tests/
-└── features/
-    └── <feature-slug>/
-        ├── <component>.test.<ext>    # Unit tests (when design is available)
-        ├── <feature-slug>.test.<ext> # Integration tests
-        └── <feature-slug>.e2e.<ext>  # End-to-end tests (if applicable)
+tests/features/<feature-slug>/
+├── <component>.test.<ext>       # Unit
+├── <feature-slug>.test.<ext>    # Integration
+└── <feature-slug>.e2e.<ext>     # E2E
 ```
 
 ### Write test files
 
-For each test file, include:
-
+Header pattern:
 ```
-// Test file header pattern (adapt to language/framework)
-//
-// Feature: <feature-slug>
-// Spec version: <spec version>
-// Generated from: spec.adoc
-//
-// Spec coverage:
-//   PROD-001: displays products in grid or list format
-//   PROD-002: category filtering
-//   ...
+// Feature: <slug>  |  Spec version: <version>  |  Source: spec.adoc
+// Coverage: PROD-001, PROD-002, ...
 ```
 
-Each test block:
-
+Test block pattern:
 ```
-describe("<PREFIX>-<NNN>: <requirement summary>", () => {
-  it("should <verification description - happy path>", () => {
-    // Test implementation derived from spec verification field
-  });
-
-  it("should <edge case or error scenario>", () => {
-    // Additional test derived from EARS type analysis
-  });
+describe("<PREFIX>-<NNN>: <summary>", () => {
+  it("should <happy path from verification>", () => { ... });
+  it("should <edge case from EARS type>", () => { ... });
 });
 ```
 
 ### Verify
 
-Tests are generated **before implementation** and serve as the acceptance gate. After writing tests:
-
-1. **Compile/parse verification:** Run the build or type-check step to confirm all test files are syntactically valid and compile without errors. Tests must not have import errors, type errors, or syntax issues.
-2. **Do NOT expect tests to pass at runtime.** There is no implementation yet -- failing tests are the expected state and represent the work `needs-implementation` must complete.
-3. **Verify 100% spec coverage:** every spec ID MUST have at least one corresponding test. If any spec ID is missing a test, this step fails -- go back and generate the missing tests.
-4. Check that test organization follows project conventions.
-
-### Report results
-
-Return to the orchestrator:
-```
-Tests generated:
-  Files: N new, N modified
-  Test cases: N total (N unit, N integration, N e2e)
-  Spec coverage: N/N requirement IDs covered (MUST be 100%)
-  Compile check: pass/fail
-  Constraint requirements: [coverage threshold, test type requirements]
-```
-
-Tests are now ready to serve as the acceptance gate for `needs-implementation`. Implementation is complete when all spec-derived tests pass.
+1. **Compile/parse check:** all test files must be syntactically valid. No import, type, or syntax errors.
+2. **Do NOT expect runtime passes.** No implementation exists yet -- failing tests are expected.
+3. **100% spec coverage:** every spec ID MUST have a test. Missing = go back and generate it.
 
 ## Quality Checklist
 
-Before finalizing, verify:
-- **Every spec ID has at least one test case -- no exceptions.** A spec requirement without a test is a blocking gap.
-- Test descriptions reference their spec ID for traceability
-- Tests follow the project's existing conventions (naming, structure, assertion style)
-- Edge cases and error scenarios are covered (especially for unwanted-behavior EARS types)
-- Tests use existing test infrastructure (no duplicate helpers or fixtures)
-- Test file organization matches project conventions
-- All test files compile/parse without errors (runtime failures are expected before implementation)
-- Coverage constraints from `constraints.adoc` are satisfied
-- All tests pass (or failures are reported with analysis)
-- Coverage constraints from `docs/constraints.adoc` are satisfied
-- Spec version is recorded in test file headers for staleness detection
+- Every spec ID has at least one test case -- no exceptions
+- Test descriptions reference spec IDs
+- Tests follow project conventions
+- Edge cases and error scenarios covered (especially unwanted-behavior EARS types)
+- No duplicate helpers or fixtures
+- All test files compile without errors
+- Coverage constraints from `docs/constraints.adoc` satisfied
+- Spec version recorded in test file headers
 
 ## Reference
 
-See `references/example.adoc` for a complete example showing how feature specifications become executable test cases.
+See `references/example.adoc` for a complete example.

--- a/skills/proven-needs/SKILL.md
+++ b/skills/proven-needs/SKILL.md
@@ -27,38 +27,23 @@ Observe → Declare → Evaluate → Derive → Execute → Validate → Repeat
 
 The observable, verifiable reality of the system right now. Computed fresh each invocation, never stored.
 
-**Artifact state:**
-- Which feature packages exist in `docs/features/`
-- For each feature: which artifacts exist (stories, spec, design, tasks), their versions, statuses
-- Project-wide artifacts: `docs/constraints.adoc`, `docs/adrs/`, `docs/architecture.adoc`, `docs/state-log.adoc`
-- Staleness: are any artifacts out of sync with their upstream?
+**Artifact state:** which feature packages exist in `docs/features/`, their artifacts, versions, statuses, and staleness. Project-wide artifacts: `docs/constraints.adoc`, `docs/adrs/`, `docs/architecture.adoc`, `docs/state-log.adoc`.
 
-**Codebase state:**
-- Language, framework, project structure
-- Dependency graph and versions (from package.json, Cargo.toml, go.mod, etc.)
-- Test coverage and test status
-- Lint and build status
-- Security posture (known vulnerabilities in dependencies)
+**Codebase state:** language, framework, project structure, dependency graph and versions, test coverage, lint/build status, security posture.
 
 ### Desired State
 
-A declarative statement of what must be true after this transition. Desired states come from:
-- The user (explicit intent)
-- The system (detected conditions, proposed to user)
+A declarative statement of what must be true after this transition. Sources: the user (explicit intent) or the system (detected conditions, proposed to user).
 
-Examples:
-- "Users can reset their password via SMS" (feature)
-- "All dependencies have no known critical vulnerabilities" (maintenance)
-- "The architecture document reflects the current system" (documentation)
-- "All API endpoints enforce rate limiting" (constraint)
+Examples: "Users can reset their password via SMS" (feature), "All dependencies have no known critical vulnerabilities" (maintenance), "All API endpoints enforce rate limiting" (constraint).
 
 ### Constraints (Invariants)
 
-Rules that must not be violated across any transition. Defined in `docs/constraints.adoc`. See the Constraints section below for the full specification.
+Rules that must not be violated across any transition. Defined in `docs/constraints.adoc`. See `references/constraints-template.adoc` for the file format and example categories.
 
 ### Feature Package
 
-A self-contained unit of work scoped to one feature. Lives in `docs/features/<slug>/`:
+A self-contained unit of work scoped to one feature at `docs/features/<slug>/`:
 
 ```
 docs/features/<slug>/
@@ -68,11 +53,11 @@ docs/features/<slug>/
 └── tasks.adoc           # WORK: phased implementation breakdown
 ```
 
-Each feature package is fully independent -- it can be specified, designed, and implemented without reading other feature packages. Feature designs reference project-wide ADRs and architecture but never other feature designs.
+Each feature package is fully independent -- no cross-feature dependencies. Feature designs reference project-wide ADRs and architecture but never other feature designs.
 
 ### State Log
 
-An append-only audit trail of all state transitions. Lives at `docs/state-log.adoc`. See the State Log section below for the format.
+An append-only audit trail of all state transitions at `docs/state-log.adoc`. See `references/state-log-template.adoc` for format.
 
 ## Capabilities
 
@@ -80,19 +65,15 @@ The orchestrator does not produce artifacts directly. It invokes capabilities (t
 
 ### Invoking a capability
 
-To invoke a capability, **load its skill by name** using the skill-loading tool (e.g., load `needs-stories`). Each capability is a separate skill with its own instructions for artifact format, versioning, quality checks, and the observe/evaluate/execute cycle.
-
-**Do NOT attempt to perform a capability's work without first loading its skill definition.** The orchestrator's job is to plan and coordinate -- the capability skills contain the detailed instructions for producing correct artifacts.
+**Load each capability skill by name** using the skill-loading tool before performing its work. Do NOT attempt to produce artifacts without loading the skill definition first. The orchestrator plans and coordinates; capability skills contain the detailed artifact instructions.
 
 Invocation steps:
 1. Load the skill by name (e.g., `needs-stories`, `needs-spec`, `needs-design`)
-2. The capability skill will run its own observe -> evaluate -> execute cycle
-3. Wait for the capability to complete and return its report before proceeding to the next capability
-4. If a capability skill references another skill (e.g., `needs-design` may load `needs-adr`), that skill must also be loaded
+2. The capability runs its own observe → evaluate → execute cycle
+3. Wait for completion before proceeding to the next capability
+4. If a capability references another skill (e.g., `needs-design` may load `needs-adr`), that skill must also be loaded
 
 ### Feature-scoped capabilities
-
-These operate within a single feature package:
 
 | Capability | Skill | Domain |
 |---|---|---|
@@ -104,8 +85,6 @@ These operate within a single feature package:
 | Implementation | `needs-implementation` | Write and verify code for a feature |
 
 ### Project-wide capabilities
-
-These operate at the project level:
 
 | Capability | Skill | Domain |
 |---|---|---|
@@ -129,33 +108,26 @@ When this skill is invoked, immediately build the current state model:
 
 #### 1.1 Read project-wide artifacts
 
-1. **`docs/constraints.adoc`** -- read all constraint categories and rules. If missing, note that no constraints are defined. Do not create it automatically -- the user declares constraints intentionally.
+1. **`docs/constraints.adoc`** -- read all constraint categories and rules. If missing, note it. Do not create it automatically -- constraints are declared intentionally.
 
-2. **`docs/features/`** -- list all feature directories. For each, check which artifacts exist and read their `:version:` and `:status:` attributes. Features with `:status: Archived` in `user-stories.adoc` are reported in the summary but skipped during intent classification and staleness checks.
+2. **`docs/features/`** -- list all feature directories. For each, check which artifacts exist and read their `:version:` and `:status:` attributes. Features with `:status: Archived` are reported but skipped during intent classification and staleness checks.
 
-3. **`docs/adrs/`** -- read the index, note how many ADRs exist and their statuses.
+3. **`docs/adrs/`** -- read the index, note counts and statuses.
 
 4. **`docs/architecture.adoc`** -- check existence, read `:version:` if present.
 
-5. **`docs/state-log.adoc`** -- check existence, read recent transitions for context. Pay particular attention to:
-   - **`:result: In Progress`** -- the prior session started a transition but ended unexpectedly (crash, context exhaustion, tool failure) without cleanly recording a result. The entry contains the intent and plan but `:capabilities-invoked:` may be empty or incomplete. Propose resuming the transition or marking it as `:result: Failed` before starting new work.
-   - **`:result: Partial`** -- the user explicitly stopped a transition mid-way. The entry lists capabilities completed vs. remaining. Propose completing the remaining capabilities before starting new work.
-   
-   In both cases, the transition's `:features:` and `:capabilities-invoked:` fields provide useful context for understanding why artifacts are in their current state (e.g., stories and spec exist but design is missing because a prior transition was interrupted).
+5. **`docs/state-log.adoc`** -- check existence, read recent transitions. Pay particular attention to:
+   - **`:result: In Progress`** -- prior session ended unexpectedly. Propose resuming or marking as Failed before starting new work.
+   - **`:result: Partial`** -- user explicitly stopped mid-transition. Propose completing remaining capabilities before starting new work.
 
 #### 1.2 Analyze codebase
 
-1. **Project type** -- detect language, framework, build system from configuration files (package.json, Cargo.toml, go.mod, pyproject.toml, etc.)
-
-2. **Dependencies** -- parse dependency files. Identify outdated packages, known vulnerabilities, archived/unmaintained packages, license information.
-
-3. **Quality signals** -- check if build passes, linting passes, tests pass. Read test coverage if available.
-
-4. **Code structure** -- understand directory layout, module organization, existing patterns.
+1. **Project type** -- detect language, framework, build system from config files
+2. **Dependencies** -- parse dependency files for outdated packages, vulnerabilities, license info
+3. **Quality signals** -- build, lint, test status and coverage
+4. **Code structure** -- directory layout, module organization, existing patterns
 
 #### 1.3 Present state summary
-
-Present a concise summary to the user:
 
 ```
 Current state:
@@ -177,243 +149,72 @@ Classify the desired state into one or more intent types:
 
 | Intent Type | Signals | Example |
 |---|---|---|
-| **Feature evolution** | Describes user-facing capability, has a user journey | "Users can reset password via SMS" |
-| **Constraint declaration** | Universal quantifiers, system-as-subject, applies to features that don't exist yet | "All API endpoints must enforce rate limiting" |
+| **Feature evolution** | User-facing capability, user journey | "Users can reset password via SMS" |
+| **Constraint declaration** | Universal quantifiers, system-as-subject, future-proof | "All API endpoints must enforce rate limiting" |
 | **Artifact maintenance** | References existing artifacts, sync/update language | "Specs are in sync with current stories" |
 | **Dependency maintenance** | References packages, versions, vulnerabilities | "No dependencies have known vulnerabilities" |
 | **Architecture evolution** | References system structure, technology changes | "Authentication uses OAuth2 instead of sessions" |
 | **Quality improvement** | References tests, coverage, code quality | "All API endpoints have integration tests" |
 | **Documentation** | References docs, architecture document | "Architecture doc reflects current system" |
 
-```mermaid
-flowchart TD
-    INPUT["User intent"] --> SIGNALS{"Analyze<br/>signals"}
-
-    SIGNALS -->|"User journey,<br/>user-facing capability"| FEAT["Feature evolution"]
-    SIGNALS -->|"Universal quantifiers,<br/>system-as-subject"| CONST["Constraint declaration"]
-    SIGNALS -->|"References artifacts,<br/>sync/update language"| ART["Artifact maintenance"]
-    SIGNALS -->|"References packages,<br/>vulnerabilities"| DEP["Dependency maintenance"]
-    SIGNALS -->|"System structure,<br/>technology changes"| ARCH["Architecture evolution"]
-    SIGNALS -->|"Tests, coverage,<br/>code quality"| QUAL["Quality improvement"]
-    SIGNALS -->|"References docs,<br/>architecture document"| DOC["Documentation"]
-```
-
 #### 2.2 Constraint detection
 
-Before proceeding with feature decomposition, check whether the intent is actually a constraint. An intent is a constraint if:
+Before feature decomposition, check whether the intent is actually a constraint. An intent is a constraint if it has all four properties:
 
-1. **Universal scope** -- it uses quantifiers like "all", "every", "no X may", "must always", "never"
-2. **System-as-subject** -- it describes a property of the system, not a capability for a user
-3. **No user journey** -- there is no identifiable user role, action, or benefit
-4. **Future-proof** -- it would apply to features that don't exist yet
+1. **Universal scope** -- quantifiers like "all", "every", "no X may", "must always", "never"
+2. **System-as-subject** -- describes a system property, not a user capability
+3. **No user journey** -- no identifiable user role, action, or benefit
+4. **Future-proof** -- applies to features that don't exist yet
 
-```mermaid
-flowchart TD
-    INTENT["Intent statement"] --> Q1{"Universal scope?<br/>(all, every, never)"}
+If the intent is a constraint: propose adding it to `docs/constraints.adoc`, ask for confirmation, update the file and state log. Do not create a feature package.
 
-    Q1 -->|Yes| Q2{"System-as-subject?<br/>(property of system,<br/>not user capability)"}
-    Q1 -->|No| FEATURE["Feature requirement"]
-
-    Q2 -->|Yes| Q3{"No user journey?<br/>(no role, action,<br/>or benefit)"}
-    Q2 -->|No| FEATURE
-
-    Q3 -->|Yes| Q4{"Future-proof?<br/>(applies to features<br/>that don't exist yet)"}
-    Q3 -->|No| ASK["Ask user:<br/>constraint or<br/>feature requirement?"]
-
-    Q4 -->|Yes| CONSTRAINT["Constraint<br/>→ add to docs/constraints.adoc"]
-    Q4 -->|No| ASK
-```
-
-If the intent is a constraint:
-- Propose adding it to `docs/constraints.adoc` with the appropriate category
-- Ask the user to confirm
-- If confirmed, update `docs/constraints.adoc` and record the transition in the state log
-- Do not create a feature package
-
-If uncertain, ask the user:
-```
-Your intent could be interpreted as:
-  1. A project-wide constraint (enforced on all features, current and future)
-  2. A feature-specific requirement (applies only to one feature)
-
-Which did you mean?
-```
+If uncertain, ask: "Is this a project-wide constraint (enforced everywhere, current and future) or a feature-specific requirement?"
 
 #### 2.3 Feature decomposition (for feature evolution intents)
 
-```mermaid
-flowchart TD
-    START((Intent)) --> CHECK{Existing<br/>features?}
-
-    CHECK -->|No: Greenfield| GF_P1
-    CHECK -->|Yes: Evolution| EV_P1
-
-    subgraph greenfield ["Greenfield Path"]
-        GF_P1["Pass 1: Draft stories<br/>into _drafts/ temp slug"]
-        GF_COHESION["Analyze cohesion<br/>(shared data, journey,<br/>independent value)"]
-        GF_PROPOSE["Propose feature<br/>groupings to user"]
-        GF_CONFIRM{User<br/>confirms?}
-        GF_P2["Pass 2: Distribute stories<br/>into feature packages"]
-        GF_CLEANUP["Remove _drafts/"]
-
-        GF_P1 --> GF_COHESION
-        GF_COHESION --> GF_PROPOSE
-        GF_PROPOSE --> GF_CONFIRM
-        GF_CONFIRM -->|Yes| GF_P2
-        GF_CONFIRM -->|Adjust| GF_PROPOSE
-        GF_P2 --> GF_CLEANUP
-    end
-
-    subgraph evolution ["Evolution Path"]
-        EV_P1["Pass 1: Draft stories<br/>into _drafts/ temp slug"]
-        EV_CLASSIFY["Classify against<br/>existing features<br/>(extends / new / updates)"]
-        EV_PROPOSE["Present mapping<br/>to user"]
-        EV_CONFIRM{User<br/>confirms?}
-        EV_P2["Pass 2: Distribute<br/>(add to existing /<br/>create new packages)"]
-        EV_CLEANUP["Remove _drafts/"]
-
-        EV_P1 --> EV_CLASSIFY
-        EV_CLASSIFY --> EV_PROPOSE
-        EV_PROPOSE --> EV_CONFIRM
-        EV_CONFIRM -->|Yes| EV_P2
-        EV_CONFIRM -->|Adjust| EV_PROPOSE
-        EV_P2 --> EV_CLEANUP
-    end
-
-    GF_CLEANUP --> DONE((Feature packages<br/>ready))
-    EV_CLEANUP --> DONE
-```
-
-**When no features exist yet (greenfield):**
-
-This uses a two-pass approach because `needs-stories` operates within a feature package (requires a slug), but feature groupings aren't known until stories are drafted.
+Uses a two-pass approach because `needs-stories` operates within a feature package (requires a slug), but feature groupings aren't known until stories are drafted.
 
 **Pass 1 -- Draft stories with a temporary slug:**
 
-1. Invoke `needs-stories` with a temporary working slug (e.g., `_drafts`) to derive user stories from the intent. This produces an initial set of stories without committing to a feature structure.
+1. Invoke `needs-stories` with slug `_drafts` to derive user stories from the intent
 2. Analyze story cohesion to propose feature groupings:
-   - Stories that share the same data entities → same feature
+   - Stories sharing data entities → same feature
    - Stories in the same user journey → same feature
-   - Stories that can deliver independent value → separate features
-3. Present the proposed grouping to the user:
-   ```
-   Based on your intent, I propose 2 features:
-
-   Feature 1: user-authentication
-     - US-001: User Registration
-     - US-002: User Login
-     - US-003: Password Reset
-     (Share auth flow and user credentials)
-
-   Feature 2: user-profile
-     - US-004: View Profile
-     - US-005: Edit Profile
-     (Independent of auth, operate on profile data)
-
-   Adjust grouping?
-   ```
-4. Wait for user confirmation before creating feature packages.
+   - Stories delivering independent value → separate features
+3. **When features already exist:** classify each drafted story against existing features (extends / new / updates) using keyword matching, data entity overlap, and user journey alignment
+4. Present the proposed grouping to the user and wait for confirmation
 
 **Pass 2 -- Distribute stories into feature packages:**
 
-5. For each confirmed feature, invoke `needs-stories` with the final slug to create the feature's `user-stories.adoc`, distributing the drafted stories into their assigned feature packages. Story IDs are reassigned to be sequential within each feature (US-001, US-002, ...).
-6. Remove the temporary `_drafts` directory if it was created on disk.
-
-**When features already exist (evolution):**
-
-This also uses a two-pass approach. Stories are drafted first, then classified against existing features.
-
-**Pass 1 -- Draft stories and classify:**
-
-1. Observe existing features and their stories.
-2. Invoke `needs-stories` with a temporary working slug (e.g., `_drafts`) to derive stories from the new intent.
-3. Classify each drafted story against existing features:
-   - **Extends existing:** Story shares data/state/journey with an existing feature → propose adding to that feature
-   - **New feature:** Story doesn't fit any existing feature → propose new feature package
-   - **Updates existing:** Story modifies behavior already covered by an existing feature → propose updating that feature
-4. Classification heuristics:
-   - Match story keywords against existing feature stories and specs
-   - Check if the story's data entities overlap with an existing feature
-   - Check if the story belongs to the same user journey as an existing feature
-5. Present the mapping to the user for confirmation:
-   ```
-   This intent maps to:
-
-   Extend: user-authentication/ (existing)
-     - Add story: SMS Password Reset
-     - Update spec and design for SMS flow
-
-   Create: notification-preferences/ (new)
-     - Manage Notification Channels
-     - Set Notification Preferences
-
-   Confirm or adjust?
-   ```
-
-**Pass 2 -- Distribute stories:**
-
-6. For stories assigned to existing features, invoke `needs-stories` (add mode) for each feature with the relevant stories.
-7. For stories assigned to new features, invoke `needs-stories` (create mode) for each new feature.
-8. Remove the temporary `_drafts` directory if it was created on disk.
+5. For each confirmed feature, invoke `needs-stories` with the final slug. Story IDs are reassigned sequentially within each feature (US-001, US-002, ...).
+6. Remove the temporary `_drafts` directory
 
 **Constraint surfacing during decomposition:**
 
-While deriving stories and specs, if a requirement is identified as cross-cutting:
-1. Flag it as a potential constraint
-2. Present to the user:
-   ```
-   While deriving specs for user-authentication, I found a cross-cutting requirement:
-     "Passwords must be at least 8 characters with mixed case and numbers"
-
-   This applies to registration, password reset, and any future password feature.
-
-   Options:
-     1. Add to docs/constraints.adoc (recommended -- enforced everywhere)
-     2. Keep as feature spec (only enforced in this feature)
-   ```
+If a requirement is identified as cross-cutting while deriving stories/specs, flag it as a potential constraint and ask the user whether to add it to `docs/constraints.adoc` (recommended) or keep it as a feature spec.
 
 ### 3. Evaluate Feasibility
 
-For each feature in the transition plan, check:
+For each feature in the transition plan:
 
 #### 3.1 Precondition check
 
-Does the desired state require artifacts that don't exist yet? For each involved capability:
-- `needs-spec` requires stories → are stories available?
-- `needs-design` requires stories and spec → are both available?
-- `needs-tasks` works best with design → is design available?
-- `needs-implementation` requires at minimum a design → does one exist?
-- `needs-tests` requires spec → is the spec available? (Tests are derived before implementation and serve as the acceptance gate.)
+Does the desired state require artifacts that don't exist yet? Capability dependencies:
+- `needs-spec` requires stories
+- `needs-design` requires stories and spec
+- `needs-tasks` works best with design
+- `needs-implementation` requires at minimum a design
+- `needs-tests` requires spec
 
-If preconditions are unmet, the orchestrator can satisfy them as part of the transition (by invoking earlier capabilities first). This is not a pipeline -- the orchestrator dynamically determines what's needed.
+If preconditions are unmet, satisfy them by invoking earlier capabilities first. This is not a rigid pipeline -- the orchestrator dynamically determines what's needed.
 
 #### 3.2 Constraint check
 
-Test the proposed transition against all constraints in `docs/constraints.adoc`:
-- Would any constraint be violated by the proposed changes?
-- Are there existing constraint violations that should be resolved first?
-
-If a constraint would be violated:
-```
-Constraint violation detected:
-
-  Architecture constraint: "Business logic resides in the service layer"
-  Proposed design places validation logic in route handlers.
-
-Options:
-  1. Revise the design to satisfy the constraint
-  2. Update the constraint (requires justification)
-  3. Abort this transition
-```
+Test the proposed transition against all constraints in `docs/constraints.adoc`. If a constraint would be violated, present options: revise the approach, update the constraint (requires justification), or abort.
 
 #### 3.3 Staleness check
 
-Check if any existing artifacts involved in the transition are stale:
-- Feature stories updated but spec not synced?
-- Spec updated but design not refreshed?
-- Feature implemented but architecture not updated?
-
-Report staleness and recommend resolution before proceeding.
+Check if existing artifacts involved in the transition are stale (stories updated but spec not synced, spec updated but design not refreshed, etc.). Recommend resolution before proceeding.
 
 ### 4. Derive Transition Plan
 
@@ -422,18 +223,11 @@ Build a dependency graph of capability invocations. The graph is derived, not ha
 **For each feature in scope:**
 
 1. Determine which artifacts need creating or updating
-2. Order capabilities by dependency: stories → specs → design → tasks → tests → implementation. `needs-spec` is always invoked -- every feature gets a specification. Specs are the contract between stories (WHY) and design (HOW); skipping them loses traceability and black-box testability. `needs-tests` runs before `needs-implementation` -- tests are derived from specs and serve as the acceptance gate for implementation.
-3. Skip capabilities whose artifacts are already current and satisfy the desired state (e.g., stories already exist and cover the intent)
+2. Order capabilities by dependency: stories → specs → design → tasks → tests → implementation. `needs-spec` is always invoked -- every feature gets a specification. `needs-tests` runs before `needs-implementation` -- tests are the acceptance gate for implementation.
+3. Skip capabilities whose artifacts are already current
 4. Mark which steps can run in parallel across features (independent features can be processed concurrently)
 
-**Architecture updates:**
-
-After all feature implementations in the current transition are complete, invoke `needs-architecture` if:
-- Any feature implementation changed the system's component structure (new services, new data stores, new external interfaces)
-- The architecture document doesn't exist yet
-- The architecture document is stale relative to the implemented features
-
-Do not invoke `needs-architecture` mid-transition between features -- wait until all features are implemented so the architecture document reflects the complete system state.
+**Architecture updates:** invoke `needs-architecture` after all feature implementations are complete if the system's component structure changed, the architecture document doesn't exist, or is stale.
 
 **Present the plan to the user:**
 
@@ -441,437 +235,164 @@ Do not invoke `needs-architecture` mid-transition between features -- wait until
 Transition plan to achieve "Users can reset password via SMS":
 
   Feature: user-authentication/ (extend existing)
-  1. needs-stories: Add SMS password reset story
-  2. needs-spec: Update spec with SMS requirements
-  3. needs-design: Update design for SMS flow
-  4. needs-tasks: Create implementation tasks
-  5. needs-tests: Generate test cases from spec (acceptance gate)
-  6. needs-implementation: Implement code changes (tests must pass)
+  1. needs-stories  2. needs-spec  3. needs-design
+  4. needs-tasks    5. needs-tests  6. needs-implementation
 
   Skipping: needs-adr (no new technology decisions)
-  Post-implementation: needs-architecture (update after implementation)
+  Post-implementation: needs-architecture
 
-  Risk: HIGH (new feature behavior, code changes)
-  Estimated artifacts affected: 4 files + tests + code
-
+  Risk: HIGH | Estimated artifacts affected: 4 files + tests + code
   Proceed?
 ```
 
 #### Execution mode
 
-After the user approves the transition plan, ask how they want the workflow to execute:
-
-```
-How should I proceed through the capabilities?
-
-  1. Autonomous -- execute all capabilities without pausing between them
-  2. Interactive -- ask for confirmation before starting each capability
-```
-
-Store the user's choice for the duration of this transition. Default to **Interactive** if the user does not express a preference.
+After the user approves, ask how to proceed:
+- **Autonomous** -- execute all capabilities without pausing
+- **Interactive** -- confirm before each capability (default)
 
 ### 5. Execute Transition
 
-**Before invoking the first capability**, append an `In Progress` entry to `docs/state-log.adoc` with the fields known so far: `:date:`, `:intent:`, `:type:`, `:risk:`, `:features:`, `:desired-state:`, `:prior-state:`, and `:result: In Progress`. Leave `:capabilities-invoked:`, `:constraints-checked:`, and `:artifacts-modified:` empty -- these are filled in when the transition completes or is stopped. This ensures that if the session ends unexpectedly, a recoverable trace exists.
+**Before the first capability**, append an `In Progress` entry to `docs/state-log.adoc` with: `:date:`, `:intent:`, `:type:`, `:risk:`, `:features:`, `:desired-state:`, `:prior-state:`, `:result: In Progress`. Leave `:capabilities-invoked:`, `:constraints-checked:`, `:artifacts-modified:` empty (filled at completion).
 
-Invoke capabilities in the derived order by loading each capability skill. For each capability:
+Invoke capabilities in derived order by loading each skill. For each:
+1. Pass feature context (slug, desired state, current state)
+2. Capability runs observe → evaluate → execute
+3. Validate output before proceeding
 
-1. The orchestrator passes the feature context (slug, desired state, current state for that feature)
-2. The capability runs its observe → evaluate → execute cycle
-3. The orchestrator validates the capability's output before proceeding to the next
-
-**Between capabilities:**
-- Verify the artifact was created/updated correctly
-- Check that no constraints were violated
-- Update the state model
+**Between capabilities:** verify artifact correctness, check constraints, update state model.
 
 ### Transition progress tracking
 
-Maintain an explicit checklist of all capabilities to invoke for this transition. Use the todo-list tool if available. After each capability completes, mark it done.
+Use the todo-list tool to track all capabilities. After each completes, mark it done.
 
-**Execution mode behavior:**
-- **Interactive mode:** After each capability completes, present the updated checklist and ask the user whether to continue to the next capability. Show which capabilities are done, which is next, and which remain.
-- **Autonomous mode:** After each capability completes, immediately proceed to the next capability without asking. Report progress inline (e.g., "needs-stories complete, proceeding to needs-spec...").
+- **Interactive mode:** present updated checklist after each capability, ask to continue
+- **Autonomous mode:** proceed immediately, report progress inline
 
-In both modes, the following rules apply:
-- **Do NOT skip capabilities in the plan.** Every capability in the derived transition plan must be invoked unless the user explicitly asks to stop.
-- **Do NOT treat `needs-implementation` as the final step.** Post-implementation capabilities (`needs-architecture`, design divergence resolution) are part of the plan and must execute. Note: `needs-tests` runs *before* implementation -- tests are the acceptance gate, not a post-implementation step.
-- If the user asks to stop mid-transition, update the existing `In Progress` entry in `docs/state-log.adoc`: set `:result: Partial`, fill in `:capabilities-invoked:` with capabilities completed so far, and add `:capabilities-remaining:` listing what was not yet invoked.
-- When a new session starts, the Observe phase (step 1) reads the state-log for `:result: Partial` or `:result: In Progress` entries. Either indicates incomplete work -- propose completing it before starting new work.
+Rules:
+- **Do NOT skip capabilities in the plan** unless the user explicitly asks to stop
+- **Do NOT treat `needs-implementation` as the final step** -- post-implementation capabilities (architecture, divergence resolution) are part of the plan
+- If stopping mid-transition: set `:result: Partial` in the state log entry, list completed and remaining capabilities
 
-**Design divergence resolution (after `needs-implementation` completes):**
+**Design divergence resolution (after `needs-implementation`):**
 
-```mermaid
-sequenceDiagram
-    participant Impl as needs-implementation
-    participant Orch as Orchestrator
-    participant User as User
-    participant Design as needs-design
+When `needs-implementation` finishes, it reports divergences between the design and what was built. For each divergence it provides: what was specified vs. implemented, analysis of both resolution directions, and rationale.
 
-    Impl->>Orch: Report divergences<br/>(design vs. actual)
-    Orch->>User: Present each divergence<br/>with analysis of both directions
+Present this to the user. For each divergence:
+- "update design" → invoke `needs-design` (reconciliation mode)
+- "fix code" → re-invoke `needs-implementation` with the specific fix
 
-    loop For each divergence
-        User->>Orch: Choose resolution
-        alt Update design
-            Orch->>Design: Reconciliation mode<br/>(divergence details)
-            Design->>Orch: Design updated
-        else Fix code
-            Orch->>Impl: Fix specific divergence
-            Impl->>Orch: Code fixed
-        end
-    end
-
-    Orch->>Orch: Continue to validation
-```
-
-When `needs-implementation` finishes, it reports any divergences between the design and what was actually built. For each divergence, it provides:
-- What the design specified vs. what was implemented
-- Analysis of both resolution directions: (a) update the design to match implementation, (b) fix the code to match the design
-- Rationale for why the implementation diverged (practical constraints, better approach discovered, etc.)
-
-Present this analysis to the user with enough context to make a good decision. For each divergence:
-- If the user chooses "update design" → invoke `needs-design` (reconciliation mode) with the divergence details
-- If the user chooses "fix code" → re-invoke `needs-implementation` with the specific fix
-- The user may choose different resolutions for different divergences
-
-**Divergence report verification:**
-After `needs-implementation` completes, verify that it produced a divergence report. If no report was provided (neither divergences nor an explicit "no divergences" confirmation), request the report before proceeding to post-implementation steps.
+After `needs-implementation` completes, verify it produced a divergence report (either divergences or explicit "no divergences" confirmation). Request the report if missing.
 
 **Error handling:**
-- If a capability fails validation → stop, report to user, ask how to proceed
-- If a constraint is violated during execution → stop, report, offer to revise or abort
-- If the user wants to stop mid-transition → save progress, update the `In Progress` entry to `:result: Partial` in state log
+- Capability fails validation → stop, report, ask how to proceed
+- Constraint violated → stop, report, offer to revise or abort
+- User stops mid-transition → set `:result: Partial` in state log
 
 ### 6. Validate
 
-After all capabilities in the transition have executed:
-
+After all capabilities have executed:
 1. Re-observe the current state
 2. Compare against the original desired state
 3. Verify all constraints still hold
 4. Run verification commands (build, test, lint) if code was changed
 
-**If desired state achieved:**
-- Update the existing `In Progress` entry in `docs/state-log.adoc`: set `:result: Achieved`, fill in `:capabilities-invoked:`, `:constraints-checked:`, and `:artifacts-modified:`
-- Report success to user
-
-**If desired state NOT achieved:**
-- Identify what's missing
-- Propose additional steps or report what went wrong
-- Do not update the entry to `:result: Achieved` -- leave as `In Progress` until resolved, or set to `:result: Failed` if unrecoverable
+If achieved: update state log entry to `:result: Achieved`. If not: identify what's missing, propose additional steps, leave as `In Progress` or set to `Failed`.
 
 ### 7. Record Transition
 
-Update the existing `In Progress` entry in `docs/state-log.adoc` with the final result. The entry was created at the start of Step 5 -- now fill in `:capabilities-invoked:`, `:constraints-checked:`, `:artifacts-modified:`, and set `:result:` to `Achieved`, `Partial`, or `Failed`. See the State Log section for format.
+Update the `In Progress` entry in `docs/state-log.adoc` with the final result: fill in `:capabilities-invoked:`, `:constraints-checked:`, `:artifacts-modified:`, and set `:result:` to `Achieved`, `Partial`, or `Failed`.
 
-## Risk Classification and Auto-Approve
+## Risk Classification
 
-```mermaid
-flowchart TD
-    CHANGE["Proposed transition"] --> FACTORS["Assess risk factors"]
+Transitions are classified by risk:
 
-    FACTORS --> SCOPE{"Scope:<br/>artifacts/files<br/>affected?"}
-    FACTORS --> PROX{"Constraint<br/>proximity?"}
-    FACTORS --> REV{"Reversibility?"}
-    FACTORS --> CODE{"Code<br/>impact?"}
-
-    SCOPE --> CLASSIFY{"Risk<br/>classification"}
-    PROX --> CLASSIFY
-    REV --> CLASSIFY
-    CODE --> CLASSIFY
-
-    CLASSIFY -->|"Patch deps, doc fixes,<br/>metadata, sync unchanged"| LOW["Low risk"]
-    CLASSIFY -->|"Minor deps, design adjust,<br/>add specs for existing stories"| MED["Medium risk"]
-    CLASSIFY -->|"New features, breaking changes,<br/>arch changes, major bumps, code"| HIGH["High risk"]
-
-    LOW --> AUTO["Auto-approve:<br/>execute immediately"]
-    MED --> PROPOSE["Propose with summary,<br/>ask user"]
-    HIGH --> REQUIRE["Full plan,<br/>require approval"]
-```
-
-Transitions are classified by risk level:
-
-| Risk Level | Auto-approve? | Criteria |
+| Risk | Auto-approve? | Criteria |
 |---|---|---|
-| **Low** | Yes, execute immediately | Patch dependency updates; sync specs with unchanged story semantics; format/metadata fixes; documentation updates |
-| **Medium** | Propose with summary, ask | Minor dependency updates; design adjustments for modified stories; adding specs for existing stories |
-| **High** | Full plan, require approval | New features; breaking changes; architecture changes; major version bumps; constraint modifications; code changes |
+| **Low** | Yes, execute immediately | Patch deps, metadata fixes, sync with unchanged semantics |
+| **Medium** | Propose with summary, ask | Minor deps, design adjustments, adding specs for existing stories |
+| **High** | Full plan, require approval | New features, breaking changes, arch changes, major bumps, code |
 
-**Risk factors:**
-- Scope: How many artifacts/files are affected?
-- Constraint proximity: Does the change approach any constraint boundary?
-- Reversibility: Can the change be undone?
-- Code impact: Does it modify production code?
+Risk factors: scope (artifacts affected), constraint proximity, reversibility, code impact.
 
-**System-proposed intents:**
-
-The orchestrator can detect conditions and propose desired states:
-- "Dependency X has a critical CVE -- desired state: X is patched" (auto-approve if patch-level)
-- "Feature user-auth specs are stale relative to stories" (propose sync, medium risk)
-- "3 features share the same password validation requirement" (propose as constraint, high risk)
-
-For auto-approved transitions, inform the user after execution:
-```
-Auto-approved: Updated lodash 4.17.20 → 4.17.21 (CVE-XXXX patched). Tests passing.
-```
+**System-proposed intents:** The orchestrator can detect conditions and propose desired states (e.g., "Dependency X has a critical CVE"). For auto-approved transitions, inform the user after execution.
 
 ## Constraints Specification
 
-### File location and format
+File: `docs/constraints.adoc`. See `references/constraints-template.adoc` for the full format and example.
 
-`docs/constraints.adoc`:
+**Lifecycle:**
+- **Adding:** classified from intent or surfaced during spec derivation. Requires user confirmation. MINOR bump.
+- **Modifying:** user explicitly requests. Requires confirmation. MINOR or MAJOR bump.
+- **Removing:** user explicitly requests. Requires confirmation with enforcement-loss warning. MAJOR bump.
 
-```asciidoc
-= Project Constraints
-:version: 1.0.0
-:last-updated: YYYY-MM-DD
-
-== Security
-
-* Passwords must be at least 8 characters with mixed case and numbers.
-* All user sessions must expire after 24 hours of inactivity.
-* No dependency with a known CRITICAL or HIGH CVE may remain unpatched for more than 7 days.
-* All user input must be validated before processing.
-
-== Licensing
-
-* Only MIT, Apache-2.0, and BSD-licensed dependencies are permitted.
-
-== API Compatibility
-
-* Public endpoints maintain backward compatibility within a MAJOR version.
-* Removal of any public endpoint requires a MAJOR version bump.
-
-== Architecture
-
-* Business logic resides in the service layer, not in route handlers.
-* No direct database access from UI components.
-
-== Quality
-
-* Test coverage must not decrease per feature implementation.
-* All code passes linting and type checking.
-
-== Performance
-
-* API P95 response time must remain below 200ms.
-```
-
-### Constraint lifecycle
-
-- **Adding:** User declares intent that is classified as constraint, or constraint is surfaced during spec derivation. Always requires user confirmation. MINOR version bump.
-- **Modifying:** User explicitly requests relaxing or tightening a rule. Requires user confirmation. MINOR or MAJOR bump depending on impact.
-- **Removing:** User explicitly requests removal. Requires confirmation with warning about enforcement loss. MAJOR version bump.
-
-Constraints are intentionally stable. Frequent constraint changes indicate they may be too specific (should be feature specs) or too vague (need refinement).
-
-### Constraint enforcement
-
-Every capability checks relevant constraints during its Evaluate phase:
-- `needs-stories`: checks quality constraints (testability, completeness)
-- `needs-spec`: checks that specs do not duplicate project-wide constraints
-- `needs-design`: checks architecture constraints
-- `needs-tasks`: checks quality constraints (testing tasks exist if coverage constraints apply)
-- `needs-implementation`: checks quality, performance, architecture constraints
-- `needs-tests`: checks quality constraints (coverage thresholds, test requirements)
-- `needs-dependencies`: checks licensing, security constraints
-- `needs-security`: checks security constraints
-- `needs-compliance`: checks licensing constraints
-
-A constraint violation blocks a transition unless the user explicitly chooses to update the constraint.
+A constraint violation blocks a transition unless the user explicitly updates the constraint.
 
 ## State Log Specification
 
-### File location and format
+File: `docs/state-log.adoc`. See `references/state-log-template.adoc` for the full format and example.
 
-`docs/state-log.adoc`:
-
-```asciidoc
-= State Transition Log
-:last-updated: YYYY-MM-DD
-
-== TRANSITION-003
-:date: 2026-02-23
-:intent: Users can reset their password via SMS
-:type: Feature evolution
-:risk: High
-:features: user-authentication (extended)
-:desired-state: SMS password reset is available alongside email reset
-:prior-state: user-authentication has email reset only (stories v1.2.0, spec v1.1.0, design v1.0.0 implemented)
-:capabilities-invoked: needs-stories, needs-spec, needs-design, needs-tasks, needs-implementation
-:constraints-checked: Security (pass), Architecture (pass), Quality (pass)
-:result: Achieved
-:artifacts-modified: docs/features/user-authentication/user-stories.adoc (v1.3.0), docs/features/user-authentication/spec.adoc (v1.2.0), docs/features/user-authentication/design.adoc (v2.0.0), docs/features/user-authentication/tasks.adoc (v1.0.0)
-
-== TRANSITION-002
-:date: 2026-02-22
-:intent: No dependencies have known vulnerabilities
-:type: Dependency maintenance
-:risk: Low (auto-approved)
-:features: n/a (project-wide)
-:desired-state: Zero known vulnerabilities in dependency graph
-:prior-state: lodash@4.17.20 has HIGH CVE
-:capabilities-invoked: needs-dependencies
-:constraints-checked: Security (triggered), Licensing (pass)
-:result: Achieved
-:artifacts-modified: package.json, package-lock.json
-
-== TRANSITION-001
-...
-```
-
-### State log conventions
-
-- Transitions are numbered sequentially (TRANSITION-001, TRANSITION-002, ...)
-- Newest transitions appear first (reverse chronological)
-- Entries are created at the start of execution with `:result: In Progress`, then updated exactly once with the final result when the transition completes or is stopped
-- `:result:` values:
-  - `In Progress` -- transition is actively executing, or the prior session ended unexpectedly before recording a final result. On session start, the Observe phase detects these and proposes resuming or marking as Failed.
-  - `Achieved` -- desired state was reached and validated
-  - `Partial` -- user explicitly stopped the transition mid-way. `:capabilities-invoked:` lists what completed; `:capabilities-remaining:` lists what was not yet invoked.
-  - `Failed` -- transition failed with a reason
+**Conventions:**
+- Numbered sequentially (TRANSITION-001, TRANSITION-002, ...), newest first
+- Created at execution start with `:result: In Progress`, updated once with final result
+- `:result:` values: `In Progress`, `Achieved`, `Partial`, `Failed`
 
 ## Feature Package Conventions
 
 ### Slug naming
 
-Feature directory names use kebab-case derived from the feature's primary purpose:
-- `user-authentication`
-- `password-reset-sms`
-- `shopping-cart`
-- `notification-preferences`
-
-Slugs are stable -- do not rename feature directories after creation. If a feature's scope changes significantly, create a new feature and archive the old one.
+Kebab-case from the feature's primary purpose (e.g., `user-authentication`, `shopping-cart`). Slugs are stable -- do not rename after creation. If scope changes significantly, create a new feature and archive the old one.
 
 ### Feature status
 
-A feature's status is derived from which artifacts exist and their states:
+Derived from which artifacts exist:
 
-```mermaid
-stateDiagram-v2
-    [*] --> Stories : user-stories.adoc created
-    Stories --> Specified : spec.adoc created
-    Specified --> Designed : design.adoc created (Current)
-    Designed --> Planned : tasks.adoc created (Current)
-    Planned --> Tested : tests generated from spec
-    Tested --> Implemented : all spec-derived tests pass
-
-    Stories --> Archived : archived
-    Specified --> Archived : archived
-    Designed --> Archived : archived
-    Planned --> Archived : archived
-    Tested --> Archived : archived
-    Implemented --> Archived : archived
-    Archived --> Stories : un-archived
-```
-
-| Artifacts Present | Derived Status |
+| Artifacts Present | Status |
 |---|---|
 | user-stories.adoc only | `Stories` |
 | + spec.adoc | `Specified` |
-| + design.adoc (status: Current) | `Designed` |
-| + tasks.adoc (status: Current) | `Planned` |
-| + test files generated from spec | `Tested` |
-| All spec-derived tests pass, implementation complete | `Implemented` |
-| `:status: Archived` in user-stories.adoc | `Archived` |
+| + design.adoc (Current) | `Designed` |
+| + tasks.adoc (Current) | `Planned` |
+| + test files from spec | `Tested` |
+| All spec-derived tests pass | `Implemented` |
+| `:status: Archived` in stories | `Archived` |
 
-**Task cleanup:** Once a feature reaches `Implemented` (all spec-derived tests pass), `tasks.adoc` is no longer needed as the completion oracle -- tests serve that role. The task file may be removed or left in place at the team's discretion. If removed, the feature remains `Implemented` as long as tests continue to pass.
+**Task cleanup:** Once `Implemented`, `tasks.adoc` may be removed -- tests serve as the completion oracle.
 
 ### Feature archival
 
-A feature is archived when its scope has fundamentally changed (superseded by a new feature), or when it is no longer relevant to the system. Archival is intentional and explicit:
+Set `:status: Archived` in `user-stories.adoc`, MAJOR version bump, record in state log. Archived features: skipped in intent classification and staleness checks, remain on disk, can be un-archived.
 
-1. Set `:status: Archived` in the feature's `user-stories.adoc`
-2. Bump the stories version (MAJOR -- breaking change)
-3. Record the archival in the state log
+### Artifact versioning
 
-**Archived features:**
-- Are skipped during intent classification (the Observe phase reports them but does not match new intents to them)
-- Are not included in staleness checks
-- Remain on disk as historical records (never deleted)
-- Can be un-archived by removing the `:status: Archived` attribute if the feature becomes relevant again
-
-### Artifact versioning within features
-
-Each artifact within a feature uses SemVer independently:
-
-| Change | Bump |
-|---|---|
-| Content removed or fundamentally rewritten | MAJOR |
-| Content added or modified (non-breaking) | MINOR |
-| Typos, formatting, metadata-only changes | PATCH |
-
-Each downstream artifact tracks its upstream:
-- `spec.adoc` tracks `:source-stories-version:`
-- `design.adoc` tracks `:source-stories-version:` and `:source-spec-version:`
-- `tasks.adoc` tracks `:source-design-version:`, `:source-stories-version:`, `:source-spec-version:`
+Each artifact uses SemVer independently: MAJOR (removed/rewritten), MINOR (added/modified), PATCH (typos/metadata). Downstream artifacts track upstream via `:source-*-version:` attributes.
 
 ### Format and dates
 
-All artifacts use AsciiDoc (`.adoc`). Dates use `YYYY-MM-DD` format. Diagrams use Mermaid. AsciiDoc artifacts use `[source,mermaid]` blocks; these render as syntax-highlighted code on GitHub and as diagrams in Asciidoctor-compatible viewers with the `asciidoctor-diagram` extension.
+All artifacts use AsciiDoc (`.adoc`). Dates: `YYYY-MM-DD`. Diagrams: Mermaid in `[source,mermaid]` blocks.
 
 ### Diagram conventions
 
-All generated documentation artifacts use Mermaid for diagrams and visual flows. When a capability produces documentation that includes architecture, component interactions, data flows, or process sequences, it embeds Mermaid diagram blocks in the AsciiDoc output.
+**Architecture documentation** uses C4 model via Mermaid (`C4Context`, `C4Container`, `C4Component`, `C4Deployment`). The `needs-architecture` skill determines which levels to include based on project complexity.
 
-**Architecture documentation** uses the C4 model via Mermaid's C4 diagram types. The orchestrator decides which levels to include based on project complexity:
-
-| C4 Level | Diagram Type | When to Include |
-|---|---|---|
-| **Level 1: System Context** | `C4Context` | Always. Shows the system, its users, and external systems. |
-| **Level 2: Container** | `C4Container` | Always. Shows major runtime containers (apps, databases, queues). |
-| **Level 3: Component** | `C4Component` | When a container has significant internal structure (e.g., service layer with multiple modules). |
-| **Level 4: Deployment** | `C4Deployment` | When the project has non-trivial deployment topology (e.g., multi-region, Kubernetes, CDN). |
-
-Guidelines for adaptive inclusion:
-- **Libraries, CLIs, simple projects:** L1 + L2 only.
-- **Web applications with separate frontend/backend:** L1 + L2 + L3 for the backend container.
-- **Microservices or distributed systems:** L1 + L2 + L3 + L4.
-
-**Feature design documentation** uses Mermaid for:
-- **Component interaction diagrams** (`flowchart`) -- how components relate and communicate
-- **Sequence diagrams** (`sequenceDiagram`) -- key user flows and system interactions
-- **State diagrams** (`stateDiagram-v2`) -- entities with meaningful state transitions
-- **Data flow diagrams** (`flowchart`) -- how data moves through the system
-
-Feature designs include at minimum one component interaction or sequence diagram for the primary flow. Additional diagrams are added when they clarify complex interactions that prose alone cannot convey efficiently.
+**Feature design documentation** uses Mermaid for component interaction diagrams, sequence diagrams, state diagrams, and data flow diagrams. At minimum one component interaction or sequence diagram per design.
 
 ### Requirement syntax
 
-All acceptance criteria and specifications use EARS sentence types. The `ears-requirements` skill provides the methodology reference.
+All acceptance criteria and specifications use EARS sentence types. Load the `ears-requirements` skill for the methodology reference.
 
 ### Black-box constraint
 
-Feature specifications describe only externally observable behavior. Internal architecture details belong in the feature design document, project-wide architecture, and ADRs.
+Feature specifications describe only externally observable behavior. Internal architecture details belong in design, architecture, and ADRs.
 
 ## Bootstrap
 
 When this skill is loaded, **immediately** check the project's `AGENTS.md` for the proven-needs workflow marker.
 
-```mermaid
-flowchart TD
-    START["Read AGENTS.md"] --> EXISTS{"File<br/>exists?"}
-
-    EXISTS -->|No| APPEND["Append proven-needs<br/>block to new file"]
-    EXISTS -->|Yes| MARKER{"proven-needs<br/>marker found?"}
-
-    MARKER -->|Yes| DONE["Do nothing<br/>(already bootstrapped)"]
-    MARKER -->|No| LEGACY{"Legacy<br/>proven-needs<br/>marker found?"}
-
-    LEGACY -->|Yes| REPLACE["Replace proven-needs<br/>block with<br/>proven-needs block"]
-    LEGACY -->|No| APPEND
-
-    REPLACE --> INFORM["Inform user<br/>AGENTS.md updated"]
-    APPEND --> INFORM
-```
-
-### Steps
-
-1. Read `AGENTS.md` in the project root (it may not exist yet).
-2. Search for the marker `<!-- proven-needs:start -->`.
-3. **If the marker is found** -- do nothing, the project is already bootstrapped.
-4. **If the marker is NOT found** -- check for the legacy marker `<!-- proven-needs:start -->`. If found, replace the entire block (from `<!-- proven-needs:start -->` to `<!-- proven-needs:end -->`) with the new block below. If neither marker exists, append the new block.
+1. Read `AGENTS.md` in the project root (may not exist).
+2. Search for `<!-- proven-needs:start -->`.
+3. **If found** -- do nothing (already bootstrapped).
+4. **If not found** -- check for legacy marker `<!-- proven-needs:start -->`. If found, replace the block. If neither exists, append the block below to the end of the file.
 
 ```markdown
 <!-- proven-needs:start -->
@@ -886,9 +407,4 @@ Load the `proven-needs` skill to start.
 
 5. Inform the user that `AGENTS.md` was updated.
 
-### Rules
-
-- This check runs **every time** the skill is loaded, but is idempotent.
-- Append to the **end** of the file to avoid disrupting existing content.
-- Do NOT modify content between the markers if the block already exists.
-- Perform this check **before** proceeding with any other workflow task.
+**Rules:** idempotent, append to end, do NOT modify existing block, run before any other workflow task.

--- a/skills/proven-needs/references/constraints-template.adoc
+++ b/skills/proven-needs/references/constraints-template.adoc
@@ -1,0 +1,33 @@
+= Project Constraints
+:version: 1.0.0
+:last-updated: YYYY-MM-DD
+
+== Security
+
+* Passwords must be at least 8 characters with mixed case and numbers.
+* All user sessions must expire after 24 hours of inactivity.
+* No dependency with a known CRITICAL or HIGH CVE may remain unpatched for more than 7 days.
+* All user input must be validated before processing.
+
+== Licensing
+
+* Only MIT, Apache-2.0, and BSD-licensed dependencies are permitted.
+
+== API Compatibility
+
+* Public endpoints maintain backward compatibility within a MAJOR version.
+* Removal of any public endpoint requires a MAJOR version bump.
+
+== Architecture
+
+* Business logic resides in the service layer, not in route handlers.
+* No direct database access from UI components.
+
+== Quality
+
+* Test coverage must not decrease per feature implementation.
+* All code passes linting and type checking.
+
+== Performance
+
+* API P95 response time must remain below 200ms.

--- a/skills/proven-needs/references/state-log-template.adoc
+++ b/skills/proven-needs/references/state-log-template.adoc
@@ -1,0 +1,43 @@
+= State Transition Log
+:last-updated: YYYY-MM-DD
+
+== TRANSITION-003
+:date: 2026-02-23
+:intent: Users can reset their password via SMS
+:type: Feature evolution
+:risk: High
+:features: user-authentication (extended)
+:desired-state: SMS password reset is available alongside email reset
+:prior-state: user-authentication has email reset only (stories v1.2.0, spec v1.1.0, design v1.0.0 implemented)
+:capabilities-invoked: needs-stories, needs-spec, needs-design, needs-tasks, needs-implementation
+:constraints-checked: Security (pass), Architecture (pass), Quality (pass)
+:result: Achieved
+:artifacts-modified: docs/features/user-authentication/user-stories.adoc (v1.3.0), docs/features/user-authentication/spec.adoc (v1.2.0), docs/features/user-authentication/design.adoc (v2.0.0), docs/features/user-authentication/tasks.adoc (v1.0.0)
+
+== TRANSITION-002
+:date: 2026-02-22
+:intent: No dependencies have known vulnerabilities
+:type: Dependency maintenance
+:risk: Low (auto-approved)
+:features: n/a (project-wide)
+:desired-state: Zero known vulnerabilities in dependency graph
+:prior-state: lodash@4.17.20 has HIGH CVE
+:capabilities-invoked: needs-dependencies
+:constraints-checked: Security (triggered), Licensing (pass)
+:result: Achieved
+:artifacts-modified: package.json, package-lock.json
+
+== TRANSITION-001
+...
+
+////
+Conventions:
+- Numbered sequentially (TRANSITION-001, TRANSITION-002, ...)
+- Newest first (reverse chronological)
+- Created at execution start with :result: In Progress, updated once with final result
+- :result: values:
+  - In Progress -- actively executing or prior session ended unexpectedly
+  - Achieved -- desired state reached and validated
+  - Partial -- user stopped mid-transition; :capabilities-remaining: lists what was not invoked
+  - Failed -- transition failed with a reason
+////


### PR DESCRIPTION
…uplication

Reduce total instruction footprint by 48% (3,901 → 2,032 lines) to improve context window efficiency and maintainability.

Orchestrator (proven-needs):
- Remove 6 Mermaid diagrams (moved to README for human readers)
- Extract constraints and state-log templates to reference files
- Consolidate repeated concepts (tests-as-gate, constraint enforcement)
- Tighten prose while preserving all behavioral instructions

Capability skills (11 files):
- Remove boilerplate preambles and report templates
- Remove orchestrator-duplicated content (C4 tables, risk classification, divergence flow)
- Fix needs-tests internal duplication (double constraints.adoc reference)
- Preserve all domain-specific instructions and quality checklists

README:
- Fix duplicate artifact traceability table rows (bug)
- Restructure as slim overview absorbing orchestrator diagrams
- Remove prose duplicated from the orchestrator skill